### PR TITLE
feat: add SAML tools section with Response Decoder

### DIFF
--- a/src/components/navigation/app-sidebar.tsx
+++ b/src/components/navigation/app-sidebar.tsx
@@ -9,7 +9,9 @@ import {
   FlaskConical,
   UserRoundSearch,
   Server,
-  UserRoundCheck
+  UserRoundCheck,
+  Shield,
+  FileCode
 } from "lucide-react"
 import { Link } from 'react-router-dom';
 
@@ -79,6 +81,18 @@ const menuTree = [
           // More flows will be added here later
         ]
       }
+    ]
+  },
+  {
+    title: "SAML Tools",
+    icon: Shield,
+    items: [
+      {
+        title: "Response Decoder",
+        url: "/saml/response-decoder",
+        icon: FileCode
+      }
+      // More SAML tools will be added here later
     ]
   }
 ];

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,20 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex min-h-[60px] w-full min-w-0 rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/src/features/saml/components/AssertionDisplay.tsx
+++ b/src/features/saml/components/AssertionDisplay.tsx
@@ -1,0 +1,196 @@
+import { DecodedSamlResponse } from "../utils/saml-decoder";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { CopyButton } from "@/components/common";
+import { User, Clock, Shield, Key } from "lucide-react";
+
+interface AssertionDisplayProps {
+  response: DecodedSamlResponse;
+}
+
+export function AssertionDisplay({ response }: AssertionDisplayProps) {
+  const formatDate = (dateString: string) => {
+    try {
+      return new Date(dateString).toLocaleString();
+    } catch {
+      return dateString;
+    }
+  };
+
+  const getAuthContextDisplay = (context?: string) => {
+    if (!context) return context;
+    const match = context.match(/:([^:]+)$/);
+    return match ? match[1] : context;
+  };
+
+  if (response.assertions.length === 0) {
+    return (
+      <div className="text-center text-muted-foreground py-8">
+        No assertions found in this SAML Response
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {response.assertions.map((assertion, index) => (
+        <div key={assertion.id} className="space-y-4">
+          {index > 0 && <Separator className="my-6" />}
+          
+          {/* Assertion Header */}
+          <div className="space-y-3">
+            <div className="flex items-center gap-2">
+              <h4 className="text-sm font-semibold">Assertion #{index + 1}</h4>
+              {assertion.hasSignature && (
+                <Badge variant="outline" className="bg-blue-500/20 text-blue-700">
+                  <Shield className="mr-1 h-3 w-3" />
+                  Signed
+                </Badge>
+              )}
+            </div>
+
+            <div className="grid grid-cols-[100px_1fr] gap-2 items-start text-sm">
+              <span className="font-medium text-muted-foreground">ID:</span>
+              <div className="flex items-center gap-2">
+                <code className="break-all">{assertion.id}</code>
+                <CopyButton text={assertion.id} showText={false} />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-[100px_1fr] gap-2 items-start text-sm">
+              <span className="font-medium text-muted-foreground">Issuer:</span>
+              <code className="break-all">{assertion.issuer}</code>
+            </div>
+
+            <div className="grid grid-cols-[100px_1fr] gap-2 items-start text-sm">
+              <span className="font-medium text-muted-foreground">Issued:</span>
+              <span>{formatDate(assertion.issueInstant)}</span>
+            </div>
+          </div>
+
+          {/* Subject */}
+          {assertion.subject && (
+            <div className="space-y-2">
+              <div className="flex items-center gap-2 text-sm font-medium">
+                <User className="h-4 w-4" />
+                <span>Subject</span>
+              </div>
+              <div className="ml-6 space-y-2">
+                {assertion.subject.nameId && (
+                  <div className="grid grid-cols-[100px_1fr] gap-2 items-start text-sm">
+                    <span className="text-muted-foreground">Name ID:</span>
+                    <code className="break-all">{assertion.subject.nameId}</code>
+                  </div>
+                )}
+                {assertion.subject.nameIdFormat && (
+                  <div className="grid grid-cols-[100px_1fr] gap-2 items-start text-sm">
+                    <span className="text-muted-foreground">Format:</span>
+                    <code className="break-all text-xs">{assertion.subject.nameIdFormat}</code>
+                  </div>
+                )}
+                {assertion.subject.confirmations?.map((conf, i) => (
+                  <div key={i} className="mt-2 space-y-1">
+                    <div className="text-sm text-muted-foreground">Confirmation #{i + 1}</div>
+                    {conf.notOnOrAfter && (
+                      <div className="ml-4 text-sm">
+                        <span className="text-muted-foreground">Not On/After:</span> {formatDate(conf.notOnOrAfter)}
+                      </div>
+                    )}
+                    {conf.recipient && (
+                      <div className="ml-4 text-sm">
+                        <span className="text-muted-foreground">Recipient:</span> <code className="text-xs">{conf.recipient}</code>
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Conditions */}
+          {assertion.conditions && (
+            <div className="space-y-2">
+              <div className="flex items-center gap-2 text-sm font-medium">
+                <Clock className="h-4 w-4" />
+                <span>Conditions</span>
+              </div>
+              <div className="ml-6 space-y-2">
+                {assertion.conditions.notBefore && (
+                  <div className="text-sm">
+                    <span className="text-muted-foreground">Not Before:</span> {formatDate(assertion.conditions.notBefore)}
+                  </div>
+                )}
+                {assertion.conditions.notOnOrAfter && (
+                  <div className="text-sm">
+                    <span className="text-muted-foreground">Not On/After:</span> {formatDate(assertion.conditions.notOnOrAfter)}
+                  </div>
+                )}
+                {assertion.conditions.audiences && assertion.conditions.audiences.length > 0 && (
+                  <div className="space-y-1">
+                    <div className="text-sm text-muted-foreground">Audiences:</div>
+                    {assertion.conditions.audiences.map((aud, i) => (
+                      <div key={i} className="ml-4">
+                        <code className="text-xs">{aud}</code>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Authentication Statement */}
+          {assertion.authnStatement && (
+            <div className="space-y-2">
+              <div className="flex items-center gap-2 text-sm font-medium">
+                <Key className="h-4 w-4" />
+                <span>Authentication</span>
+              </div>
+              <div className="ml-6 space-y-2">
+                <div className="text-sm">
+                  <span className="text-muted-foreground">Auth Time:</span> {formatDate(assertion.authnStatement.authnInstant)}
+                </div>
+                {assertion.authnStatement.sessionIndex && (
+                  <div className="text-sm">
+                    <span className="text-muted-foreground">Session:</span> <code className="text-xs">{assertion.authnStatement.sessionIndex}</code>
+                  </div>
+                )}
+                {assertion.authnStatement.authnContext && (
+                  <div className="text-sm">
+                    <span className="text-muted-foreground">Context:</span>{' '}
+                    <Badge variant="outline">{getAuthContextDisplay(assertion.authnStatement.authnContext)}</Badge>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Attributes */}
+          {assertion.attributes.length > 0 && (
+            <div className="space-y-2">
+              <div className="flex items-center gap-2 text-sm font-medium">
+                <span>Attributes</span>
+                <Badge variant="secondary">{assertion.attributes.length}</Badge>
+              </div>
+              <div className="ml-6 space-y-3">
+                {assertion.attributes.map((attr, i) => (
+                  <div key={i} className="space-y-1">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium">{attr.name}</span>
+                      <CopyButton text={attr.values.join(', ')} showText={false} />
+                    </div>
+                    {attr.values.map((value, vi) => (
+                      <div key={vi} className="ml-4 text-sm text-muted-foreground">
+                        {value}
+                      </div>
+                    ))}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/features/saml/components/ResponseDisplay.tsx
+++ b/src/features/saml/components/ResponseDisplay.tsx
@@ -1,0 +1,90 @@
+import { DecodedSamlResponse } from "../utils/saml-decoder";
+import { Badge } from "@/components/ui/badge";
+import { CopyButton } from "@/components/common";
+
+interface ResponseDisplayProps {
+  response: DecodedSamlResponse;
+}
+
+export function ResponseDisplay({ response }: ResponseDisplayProps) {
+  const formatDate = (dateString: string) => {
+    try {
+      return new Date(dateString).toLocaleString();
+    } catch {
+      return dateString;
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Response Details */}
+      <div className="space-y-3">
+        <div className="grid grid-cols-[120px_1fr] gap-2 items-start">
+          <span className="text-sm font-medium text-muted-foreground">Response ID:</span>
+          <div className="flex items-center gap-2">
+            <code className="text-sm break-all">{response.responseId}</code>
+            <CopyButton text={response.responseId} showText={false} />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-[120px_1fr] gap-2 items-start">
+          <span className="text-sm font-medium text-muted-foreground">Issuer:</span>
+          <div className="flex items-center gap-2">
+            <code className="text-sm break-all">{response.issuer}</code>
+            <CopyButton text={response.issuer} showText={false} />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-[120px_1fr] gap-2 items-start">
+          <span className="text-sm font-medium text-muted-foreground">Issue Time:</span>
+          <span className="text-sm">{formatDate(response.issueInstant)}</span>
+        </div>
+
+        {response.destination && (
+          <div className="grid grid-cols-[120px_1fr] gap-2 items-start">
+            <span className="text-sm font-medium text-muted-foreground">Destination:</span>
+            <code className="text-sm break-all">{response.destination}</code>
+          </div>
+        )}
+
+        {response.inResponseTo && (
+          <div className="grid grid-cols-[120px_1fr] gap-2 items-start">
+            <span className="text-sm font-medium text-muted-foreground">In Response To:</span>
+            <code className="text-sm break-all">{response.inResponseTo}</code>
+          </div>
+        )}
+
+        <div className="grid grid-cols-[120px_1fr] gap-2 items-start">
+          <span className="text-sm font-medium text-muted-foreground">Status:</span>
+          <div className="flex items-center gap-2">
+            <Badge 
+              variant="outline" 
+              className={response.status === "Success" ? "bg-green-500/20 text-green-700" : "bg-red-500/20 text-red-700"}
+            >
+              {response.status}
+            </Badge>
+            {response.statusMessage && (
+              <span className="text-sm text-muted-foreground">{response.statusMessage}</span>
+            )}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-[120px_1fr] gap-2 items-start">
+          <span className="text-sm font-medium text-muted-foreground">Assertions:</span>
+          <span className="text-sm">{response.assertions.length} assertion(s) found</span>
+        </div>
+      </div>
+
+      {/* Raw XML */}
+      <div className="mt-6">
+        <div className="flex items-center justify-between mb-2">
+          <h4 className="text-sm font-medium">Raw XML</h4>
+          <CopyButton text={response.xml} showText={false} />
+        </div>
+        <pre className="p-4 bg-muted rounded-lg overflow-x-auto">
+          <code className="text-xs">{response.xml}</code>
+        </pre>
+      </div>
+    </div>
+  );
+}

--- a/src/features/saml/components/SamlResponseDecoder.tsx
+++ b/src/features/saml/components/SamlResponseDecoder.tsx
@@ -1,0 +1,157 @@
+import { useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Badge } from "@/components/ui/badge";
+import { decodeSamlResponse, type DecodedSamlResponse } from "../utils/saml-decoder";
+import { ResponseDisplay } from "./ResponseDisplay";
+import { AssertionDisplay } from "./AssertionDisplay";
+import { SignatureDisplay } from "./SignatureDisplay";
+import { AlertCircle, FileCode, Shield, FileKey, CheckCircle } from "lucide-react";
+
+export function SamlResponseDecoder() {
+  const [input, setInput] = useState("");
+  const [decodedResponse, setDecodedResponse] = useState<DecodedSamlResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState("response");
+
+  const handleDecode = () => {
+    try {
+      setError(null);
+      const decoded = decodeSamlResponse(input.trim());
+      setDecodedResponse(decoded);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to decode SAML response");
+      setDecodedResponse(null);
+    }
+  };
+
+  const handleClear = () => {
+    setInput("");
+    setDecodedResponse(null);
+    setError(null);
+    setActiveTab("response");
+  };
+
+  const handleExample = () => {
+    // A simple example SAML Response (base64 encoded)
+    const exampleResponse = "PHNhbWxwOlJlc3BvbnNlIHhtbG5zOnNhbWxwPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6cHJvdG9jb2wiIHhtbG5zOnNhbWw9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDphc3NlcnRpb24iIElEPSJfOGU4ZGM1ZjY5YTk4Y2M0YzFmZjM0MjdlNWNlMzQ2MDZmZDY3MmY5MWU2IiBWZXJzaW9uPSIyLjAiIElzc3VlSW5zdGFudD0iMjAyNC0wMS0xNVQxMDozMDowMFoiIERlc3RpbmF0aW9uPSJodHRwczovL2V4YW1wbGUuY29tL3NhbWwvYWNzIiBJblJlc3BvbnNlVG89Il9hYmNkZWYxMjM0NTYiPjxzYW1sOklzc3Vlcj5odHRwczovL2lkcC5leGFtcGxlLmNvbTwvc2FtbDpJc3N1ZXI+PHNhbWxwOlN0YXR1cz48c2FtbHA6U3RhdHVzQ29kZSBWYWx1ZT0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOnN0YXR1czpTdWNjZXNzIi8+PC9zYW1scDpTdGF0dXM+PHNhbWw6QXNzZXJ0aW9uIHhtbG5zOnNhbWw9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDphc3NlcnRpb24iIElEPSJfZDcxYTNhOGU5ZmNjNDVjOWQ5MjQ4ZGY5NGZhNGI4NTFhNTcxMjA2OGY4IiBWZXJzaW9uPSIyLjAiIElzc3VlSW5zdGFudD0iMjAyNC0wMS0xNVQxMDozMDowMFoiPjxzYW1sOklzc3Vlcj5odHRwczovL2lkcC5leGFtcGxlLmNvbTwvc2FtbDpJc3N1ZXI+PHNhbWw6U3ViamVjdD48c2FtbDpOYW1lSUQgU1BOYW1lUXVhbGlmaWVyPSJodHRwczovL2V4YW1wbGUuY29tIiBGb3JtYXQ9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDpuYW1laWQtZm9ybWF0OnRyYW5zaWVudCI+X2NlM2QyOTQ4YjRjZjIwMTQ2ZGVlMGEwZTNlNjgwNmRmYmM5NGNmYWRkZjc8L3NhbWw6TmFtZUlEPjxzYW1sOlN1YmplY3RDb25maXJtYXRpb24gTWV0aG9kPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6Y206YmVhcmVyIj48c2FtbDpTdWJqZWN0Q29uZmlybWF0aW9uRGF0YSBOb3RPbk9yQWZ0ZXI9IjIwMjQtMDEtMTVUMTA6MzU6MDBaIiBSZWNpcGllbnQ9Imh0dHBzOi8vZXhhbXBsZS5jb20vc2FtbC9hY3MiIEluUmVzcG9uc2VUbz0iX2FiY2RlZjEyMzQ1NiIvPjwvc2FtbDpTdWJqZWN0Q29uZmlybWF0aW9uPjwvc2FtbDpTdWJqZWN0PjxzYW1sOkNvbmRpdGlvbnMgTm90QmVmb3JlPSIyMDI0LTAxLTE1VDEwOjI1OjAwWiIgTm90T25PckFmdGVyPSIyMDI0LTAxLTE1VDEwOjM1OjAwWiI+PHNhbWw6QXVkaWVuY2VSZXN0cmljdGlvbj48c2FtbDpBdWRpZW5jZT5odHRwczovL2V4YW1wbGUuY29tPC9zYW1sOkF1ZGllbmNlPjwvc2FtbDpBdWRpZW5jZVJlc3RyaWN0aW9uPjwvc2FtbDpDb25kaXRpb25zPjxzYW1sOkF1dGhuU3RhdGVtZW50IEF1dGhuSW5zdGFudD0iMjAyNC0wMS0xNVQxMDoyOTowMFoiIFNlc3Npb25JbmRleD0iXzQ5ZjUyYjJkNTI5YjRhODNiMGY4YjI5NmIxNzIwYjM2Ij48c2FtbDpBdXRobkNvbnRleHQ+PHNhbWw6QXV0aG5Db250ZXh0Q2xhc3NSZWY+dXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOmFjOmNsYXNzZXM6UGFzc3dvcmQ8L3NhbWw6QXV0aG5Db250ZXh0Q2xhc3NSZWY+PC9zYW1sOkF1dGhuQ29udGV4dD48L3NhbWw6QXV0aG5TdGF0ZW1lbnQ+PHNhbWw6QXR0cmlidXRlU3RhdGVtZW50PjxzYW1sOkF0dHJpYnV0ZSBOYW1lPSJlbWFpbCIgTmFtZUZvcm1hdD0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOmF0dHJuYW1lLWZvcm1hdDpiYXNpYyI+PHNhbWw6QXR0cmlidXRlVmFsdWU+am9obi5kb2VAZXhhbXBsZS5jb208L3NhbWw6QXR0cmlidXRlVmFsdWU+PC9zYW1sOkF0dHJpYnV0ZT48c2FtbDpBdHRyaWJ1dGUgTmFtZT0iZmlyc3ROYW1lIiBOYW1lRm9ybWF0PSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YXR0cm5hbWUtZm9ybWF0OmJhc2ljIj48c2FtbDpBdHRyaWJ1dGVWYWx1ZT5Kb2huPC9zYW1sOkF0dHJpYnV0ZVZhbHVlPjwvc2FtbDpBdHRyaWJ1dGU+PHNhbWw6QXR0cmlidXRlIE5hbWU9Imxhc3ROYW1lIiBOYW1lRm9ybWF0PSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YXR0cm5hbWUtZm9ybWF0OmJhc2ljIj48c2FtbDpBdHRyaWJ1dGVWYWx1ZT5Eb2U8L3NhbWw6QXR0cmlidXRlVmFsdWU+PC9zYW1sOkF0dHJpYnV0ZT48L3NhbWw6QXR0cmlidXRlU3RhdGVtZW50Pjwvc2FtbDpBc3NlcnRpb24+PC9zYW1scDpSZXNwb25zZT4=";
+    setInput(exampleResponse);
+  };
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      {/* Input Card */}
+      <Card className="lg:col-span-1">
+        <CardHeader>
+          <CardTitle>SAML Response Input</CardTitle>
+          <CardDescription>
+            Paste your base64-encoded SAML Response
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="saml-input">SAML Response (Base64)</Label>
+            <Textarea
+              id="saml-input"
+              placeholder="Paste your base64-encoded SAML Response here..."
+              value={input}
+              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setInput(e.target.value)}
+              className="min-h-[200px] font-mono text-sm"
+            />
+          </div>
+
+          {error && (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <div className="flex gap-2">
+            <Button onClick={handleDecode} disabled={!input.trim()}>
+              <FileCode className="mr-2 h-4 w-4" />
+              Decode Response
+            </Button>
+            <Button variant="secondary" onClick={handleExample}>
+              Load Example
+            </Button>
+            <Button variant="outline" onClick={handleClear}>
+              Clear
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Decoded Response Card */}
+      {decodedResponse && (
+        <Card className="lg:col-span-1">
+          <CardHeader>
+            <CardTitle className="flex items-center justify-between">
+              <span>Decoded SAML Response</span>
+              <div className="flex gap-2">
+                {decodedResponse.status === "Success" ? (
+                  <Badge variant="outline" className="bg-green-500/20 text-green-700">
+                    <CheckCircle className="mr-1 h-3 w-3" />
+                    Success
+                  </Badge>
+                ) : (
+                  <Badge variant="outline" className="bg-red-500/20 text-red-700">
+                    <AlertCircle className="mr-1 h-3 w-3" />
+                    {decodedResponse.status}
+                  </Badge>
+                )}
+                {decodedResponse.hasSignature && (
+                  <Badge variant="outline" className="bg-blue-500/20 text-blue-700">
+                    <Shield className="mr-1 h-3 w-3" />
+                    Signed
+                  </Badge>
+                )}
+              </div>
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Tabs value={activeTab} onValueChange={setActiveTab}>
+              <TabsList className="grid w-full grid-cols-3">
+                <TabsTrigger value="response">Response</TabsTrigger>
+                <TabsTrigger value="assertion">Assertion</TabsTrigger>
+                <TabsTrigger value="signature">Signature</TabsTrigger>
+              </TabsList>
+
+              <TabsContent value="response" className="mt-4">
+                <ResponseDisplay response={decodedResponse} />
+              </TabsContent>
+
+              <TabsContent value="assertion" className="mt-4">
+                <AssertionDisplay response={decodedResponse} />
+              </TabsContent>
+
+              <TabsContent value="signature" className="mt-4">
+                <SignatureDisplay response={decodedResponse} />
+              </TabsContent>
+            </Tabs>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Placeholder when no response is decoded */}
+      {!decodedResponse && !error && (
+        <Card className="lg:col-span-1">
+          <CardContent className="p-6 text-center text-muted-foreground">
+            <FileKey className="mx-auto h-12 w-12 mb-4 opacity-50" />
+            <p>Paste a SAML Response and click "Decode Response" to analyze it.</p>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/features/saml/components/SignatureDisplay.tsx
+++ b/src/features/saml/components/SignatureDisplay.tsx
@@ -1,0 +1,79 @@
+import { DecodedSamlResponse } from "../utils/saml-decoder";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Shield, AlertCircle, Info } from "lucide-react";
+
+interface SignatureDisplayProps {
+  response: DecodedSamlResponse;
+}
+
+export function SignatureDisplay({ response }: SignatureDisplayProps) {
+  const hasAnySignature = response.hasSignature || response.assertions.some(a => a.hasSignature);
+
+  if (!hasAnySignature) {
+    return (
+      <Alert>
+        <AlertCircle className="h-4 w-4" />
+        <AlertDescription>
+          This SAML Response and its assertions are not signed.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Response Signature */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <Shield className="h-4 w-4" />
+          <h4 className="text-sm font-medium">Response Signature</h4>
+        </div>
+        <div className="ml-6">
+          {response.hasSignature ? (
+            <Badge variant="outline" className="bg-blue-500/20 text-blue-700">
+              Response is signed
+            </Badge>
+          ) : (
+            <Badge variant="outline" className="bg-gray-500/20 text-gray-700">
+              Response is not signed
+            </Badge>
+          )}
+        </div>
+      </div>
+
+      {/* Assertion Signatures */}
+      {response.assertions.length > 0 && (
+        <div className="space-y-2">
+          <h4 className="text-sm font-medium">Assertion Signatures</h4>
+          <div className="ml-6 space-y-2">
+            {response.assertions.map((assertion, index) => (
+              <div key={assertion.id} className="flex items-center gap-2">
+                <span className="text-sm text-muted-foreground">Assertion #{index + 1}:</span>
+                {assertion.hasSignature ? (
+                  <Badge variant="outline" className="bg-blue-500/20 text-blue-700">
+                    Signed
+                  </Badge>
+                ) : (
+                  <Badge variant="outline" className="bg-gray-500/20 text-gray-700">
+                    Not signed
+                  </Badge>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Info Alert */}
+      <Alert>
+        <Info className="h-4 w-4" />
+        <AlertDescription>
+          Signature validation requires the IdP's public key or certificate. 
+          This tool currently shows signature presence only. 
+          Full signature validation will be added in a future update.
+        </AlertDescription>
+      </Alert>
+    </div>
+  );
+}

--- a/src/features/saml/index.tsx
+++ b/src/features/saml/index.tsx
@@ -1,0 +1,4 @@
+export { SamlResponseDecoder } from './pages';
+
+// Export pages for routing
+export { default as SamlResponseDecoderPage } from './pages/response-decoder';

--- a/src/features/saml/pages/index.tsx
+++ b/src/features/saml/pages/index.tsx
@@ -1,0 +1,1 @@
+export { SamlResponseDecoder } from './response-decoder';

--- a/src/features/saml/pages/response-decoder/index.tsx
+++ b/src/features/saml/pages/response-decoder/index.tsx
@@ -1,0 +1,18 @@
+import { PageContainer, PageHeader } from "@/components/page";
+import { SamlResponseDecoder } from "../../components/SamlResponseDecoder";
+import { Shield } from "lucide-react";
+
+export default function SamlResponseDecoderPage() {
+  return (
+    <PageContainer maxWidth='full'>
+      <PageHeader
+        title="SAML Response Decoder"
+        description="Decode and analyze SAML responses and assertions. Extract attributes, validate structure, and inspect authentication statements."
+        icon={Shield}
+      />
+      <SamlResponseDecoder />
+    </PageContainer>
+  );
+}
+
+export { SamlResponseDecoder };

--- a/src/features/saml/utils/saml-decoder.ts
+++ b/src/features/saml/utils/saml-decoder.ts
@@ -1,0 +1,253 @@
+export interface DecodedSamlResponse {
+  raw: string;
+  xml: string;
+  responseId: string;
+  issuer: string;
+  status: string;
+  statusMessage?: string;
+  issueInstant: string;
+  destination?: string;
+  inResponseTo?: string;
+  hasSignature: boolean;
+  assertions: SamlAssertion[];
+}
+
+export interface SamlAssertion {
+  id: string;
+  issuer: string;
+  issueInstant: string;
+  subject?: {
+    nameId?: string;
+    nameIdFormat?: string;
+    confirmations?: {
+      method: string;
+      notOnOrAfter?: string;
+      recipient?: string;
+      inResponseTo?: string;
+    }[];
+  };
+  conditions?: {
+    notBefore?: string;
+    notOnOrAfter?: string;
+    audiences?: string[];
+  };
+  authnStatement?: {
+    authnInstant: string;
+    sessionIndex?: string;
+    authnContext?: string;
+  };
+  attributes: {
+    name: string;
+    nameFormat?: string;
+    values: string[];
+  }[];
+  hasSignature: boolean;
+}
+
+export function decodeSamlResponse(base64Input: string): DecodedSamlResponse {
+  // Remove any whitespace
+  const cleanInput = base64Input.replace(/\s/g, '');
+  
+  let decodedXml: string;
+  try {
+    // Decode from base64
+    decodedXml = atob(cleanInput);
+  } catch (e) {
+    throw new Error('Invalid base64 encoding');
+  }
+
+  // Parse XML
+  const parser = new DOMParser();
+  const xmlDoc = parser.parseFromString(decodedXml, 'text/xml');
+  
+  // Check for XML parsing errors
+  const parserError = xmlDoc.querySelector('parsererror');
+  if (parserError) {
+    throw new Error('Invalid XML format');
+  }
+
+  // Get root element
+  const responseElement = xmlDoc.documentElement;
+  if (!responseElement || 
+      (responseElement.localName !== 'Response' && 
+       !responseElement.nodeName.endsWith(':Response'))) {
+    throw new Error('Not a valid SAML Response');
+  }
+
+  // Extract response data
+  const response: DecodedSamlResponse = {
+    raw: cleanInput,
+    xml: decodedXml,
+    responseId: responseElement.getAttribute('ID') || '',
+    issuer: extractIssuer(responseElement),
+    status: extractStatus(responseElement),
+    issueInstant: responseElement.getAttribute('IssueInstant') || '',
+    destination: responseElement.getAttribute('Destination') || undefined,
+    inResponseTo: responseElement.getAttribute('InResponseTo') || undefined,
+    hasSignature: hasSignature(responseElement),
+    assertions: extractAssertions(responseElement)
+  };
+
+  // Extract status message if present
+  const statusMessage = extractStatusMessage(responseElement);
+  if (statusMessage) {
+    response.statusMessage = statusMessage;
+  }
+
+  return response;
+}
+
+function extractIssuer(element: Element): string {
+  const issuerElement = findElement(element, 'Issuer');
+  return issuerElement?.textContent?.trim() || '';
+}
+
+function extractStatus(element: Element): string {
+  const statusCodeElement = findElement(element, 'StatusCode');
+  const statusValue = statusCodeElement?.getAttribute('Value') || '';
+  
+  // Extract the status type from the URN
+  const match = statusValue.match(/:([^:]+)$/);
+  return match ? match[1] : statusValue;
+}
+
+function extractStatusMessage(element: Element): string | undefined {
+  const statusMessageElement = findElement(element, 'StatusMessage');
+  return statusMessageElement?.textContent?.trim();
+}
+
+function hasSignature(element: Element): boolean {
+  return !!findElement(element, 'Signature', true);
+}
+
+function extractAssertions(responseElement: Element): SamlAssertion[] {
+  const assertionElements = findElements(responseElement, 'Assertion');
+  return assertionElements.map(extractAssertion);
+}
+
+function extractAssertion(assertionElement: Element): SamlAssertion {
+  const assertion: SamlAssertion = {
+    id: assertionElement.getAttribute('ID') || '',
+    issuer: extractIssuer(assertionElement),
+    issueInstant: assertionElement.getAttribute('IssueInstant') || '',
+    attributes: extractAttributes(assertionElement),
+    hasSignature: hasSignature(assertionElement)
+  };
+
+  // Extract subject
+  const subjectElement = findElement(assertionElement, 'Subject');
+  if (subjectElement) {
+    assertion.subject = extractSubject(subjectElement);
+  }
+
+  // Extract conditions
+  const conditionsElement = findElement(assertionElement, 'Conditions');
+  if (conditionsElement) {
+    assertion.conditions = extractConditions(conditionsElement);
+  }
+
+  // Extract authentication statement
+  const authnStatementElement = findElement(assertionElement, 'AuthnStatement');
+  if (authnStatementElement) {
+    assertion.authnStatement = extractAuthnStatement(authnStatementElement);
+  }
+
+  return assertion;
+}
+
+function extractSubject(subjectElement: Element): SamlAssertion['subject'] {
+  const subject: SamlAssertion['subject'] = {};
+
+  // Extract NameID
+  const nameIdElement = findElement(subjectElement, 'NameID');
+  if (nameIdElement) {
+    subject.nameId = nameIdElement.textContent?.trim();
+    subject.nameIdFormat = nameIdElement.getAttribute('Format') || undefined;
+  }
+
+  // Extract SubjectConfirmations
+  const confirmationElements = findElements(subjectElement, 'SubjectConfirmation');
+  if (confirmationElements.length > 0) {
+    subject.confirmations = confirmationElements.map(conf => {
+      const confirmation: any = {
+        method: conf.getAttribute('Method') || ''
+      };
+
+      const dataElement = findElement(conf, 'SubjectConfirmationData');
+      if (dataElement) {
+        confirmation.notOnOrAfter = dataElement.getAttribute('NotOnOrAfter') || undefined;
+        confirmation.recipient = dataElement.getAttribute('Recipient') || undefined;
+        confirmation.inResponseTo = dataElement.getAttribute('InResponseTo') || undefined;
+      }
+
+      return confirmation;
+    });
+  }
+
+  return subject;
+}
+
+function extractConditions(conditionsElement: Element): SamlAssertion['conditions'] {
+  const conditions: SamlAssertion['conditions'] = {
+    notBefore: conditionsElement.getAttribute('NotBefore') || undefined,
+    notOnOrAfter: conditionsElement.getAttribute('NotOnOrAfter') || undefined
+  };
+
+  // Extract audiences
+  const audienceElements = findElements(conditionsElement, 'Audience');
+  if (audienceElements.length > 0) {
+    conditions.audiences = audienceElements.map(aud => aud.textContent?.trim() || '');
+  }
+
+  return conditions;
+}
+
+function extractAuthnStatement(authnStatementElement: Element): SamlAssertion['authnStatement'] {
+  const authnStatement: SamlAssertion['authnStatement'] = {
+    authnInstant: authnStatementElement.getAttribute('AuthnInstant') || '',
+    sessionIndex: authnStatementElement.getAttribute('SessionIndex') || undefined
+  };
+
+  // Extract authentication context
+  const authnContextClassRef = findElement(authnStatementElement, 'AuthnContextClassRef');
+  if (authnContextClassRef) {
+    authnStatement.authnContext = authnContextClassRef.textContent?.trim();
+  }
+
+  return authnStatement;
+}
+
+function extractAttributes(assertionElement: Element): SamlAssertion['attributes'] {
+  const attributeStatementElement = findElement(assertionElement, 'AttributeStatement');
+  if (!attributeStatementElement) return [];
+
+  const attributeElements = findElements(attributeStatementElement, 'Attribute');
+  return attributeElements.map(attr => {
+    const valueElements = findElements(attr, 'AttributeValue');
+    return {
+      name: attr.getAttribute('Name') || '',
+      nameFormat: attr.getAttribute('NameFormat') || undefined,
+      values: valueElements.map(val => val.textContent?.trim() || '')
+    };
+  });
+}
+
+// Helper functions to handle XML namespaces
+function findElement(parent: Element, localName: string, directChild = false): Element | null {
+  const elements = directChild ? 
+    Array.from(parent.children) : 
+    Array.from(parent.getElementsByTagName('*'));
+  
+  return elements.find(el => 
+    el.localName === localName || 
+    el.nodeName.endsWith(`:${localName}`)
+  ) || null;
+}
+
+function findElements(parent: Element, localName: string): Element[] {
+  const allElements = Array.from(parent.getElementsByTagName('*'));
+  return allElements.filter(el => 
+    el.localName === localName || 
+    el.nodeName.endsWith(`:${localName}`)
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,6 +17,7 @@ import AuthCodeWithPkcePage from './features/oauthPlayground/pages/auth-code-pkc
 import ClientCredentialsPage from './features/oauthPlayground/pages/client-credentials'
 import IntrospectionPage from './features/oauthPlayground/pages/introspection'
 import UserInfoPage from './features/oauthPlayground/pages/userinfo'
+import SamlResponseDecoderPage from './features/saml/pages/response-decoder'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -34,6 +35,7 @@ createRoot(document.getElementById('root')!).render(
               <Route path="oauth-playground/client-credentials" element={<ClientCredentialsPage />} />
               <Route path="oauth-playground/introspection" element={<IntrospectionPage />} />
               <Route path="oauth-playground/userinfo" element={<UserInfoPage />} />
+              <Route path="saml/response-decoder" element={<SamlResponseDecoderPage />} />
             </Route>
             <Route path="oauth-playground/callback" element={<OAuthCallbackPage />} />
             <Route path="oauth-playground/demo-auth" element={<DemoAuthPage />} />


### PR DESCRIPTION
- Add new SAML Tools section to navigation menu
- Implement SAML Response Decoder tool for decoding base64 SAML responses
- Extract and display response metadata, assertions, and attributes
- Show authentication context and signature presence
- Add textarea UI component for multi-line input
- Include example SAML response for testing
- Follow existing app architecture patterns

🤖 Generated with [Claude Code](https://claude.ai/code)