### PR TITLE
refactor: improve Token Inspector UI layout and button organization

### DIFF
--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -15,9 +15,9 @@ export const selectors = {
   buttons: {
     primary: '.bg-primary',
     secondary: '.bg-secondary',
-    paste: 'button:has-text("Paste")',
     example: 'button:has-text("Example")',
-    reset: 'button:has-text("Reset")',
+    clear: 'button:has-text("Clear")',
+    reset: 'button:has-text("Clear")', // Alias for backward compatibility
     fetchConfig: 'button:has-text("Fetch Config")',
     inspectToken: 'button:has-text("Inspect Token")',
   },

--- a/e2e/tests/token-inspector.e2e.ts
+++ b/e2e/tests/token-inspector.e2e.ts
@@ -148,17 +148,4 @@ test.describe('Token Inspector', () => {
     await expect(page.locator('text=user-example-123').first()).toBeVisible();
   });
 
-  test('should handle paste functionality', async ({ page }) => {
-    // Skip clipboard test in CI environment as it's unreliable
-    // Just test that the paste button exists and is clickable
-    const pasteButton = page.locator(selectors.buttons.paste);
-    await expect(pasteButton).toBeVisible();
-    await expect(pasteButton).toBeEnabled();
-    
-    // Click it to verify it doesn't break
-    await pasteButton.click();
-    
-    // Just verify the page is still functional
-    await expect(page.locator('text=OAuth/OIDC Token').first()).toBeVisible();
-  });
 });

--- a/src/features/saml/components/SamlResponseDecoder.tsx
+++ b/src/features/saml/components/SamlResponseDecoder.tsx
@@ -15,7 +15,7 @@ import { decodeSamlResponse, type DecodedSamlResponse } from "../utils/saml-deco
 import { ResponseDisplay } from "./ResponseDisplay";
 import { AssertionDisplay } from "./AssertionDisplay";
 import { SignatureDisplay } from "./SignatureDisplay";
-import { AlertCircle, FileCode, Shield, FileKey, CheckCircle } from "lucide-react";
+import { AlertCircle, Search, Shield, FileKey, CheckCircle, TestTubeDiagonal, RotateCcw } from "lucide-react";
 
 export function SamlResponseDecoder() {
   const [input, setInput] = useState("");
@@ -70,16 +70,34 @@ export function SamlResponseDecoder() {
             </Alert>
           )}
 
-          <div className="flex gap-2">
-            <Button onClick={handleDecode} disabled={!input.trim()}>
-              <FileCode className="mr-2 h-4 w-4" />
-              Decode Response
-            </Button>
-            <Button variant="secondary" onClick={handleExample}>
-              Load Example
-            </Button>
-            <Button variant="outline" onClick={handleClear}>
-              Clear
+          <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2 mt-4">
+            <div className="flex flex-wrap gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleExample}
+                className="flex items-center gap-1.5"
+              >
+                <TestTubeDiagonal size={16} />
+                <span>Example</span>
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={handleClear}
+                className="flex items-center gap-1.5"
+              >
+                <RotateCcw size={16} />
+                <span>Clear</span>
+              </Button>
+            </div>
+            <Button
+              onClick={handleDecode}
+              disabled={!input.trim()}
+              className="w-full sm:w-auto flex items-center gap-1.5"
+            >
+              <Search size={16} />
+              <span>Decode Response</span>
             </Button>
           </div>
         </CardContent>

--- a/src/features/saml/components/SamlResponseDecoder.tsx
+++ b/src/features/saml/components/SamlResponseDecoder.tsx
@@ -52,8 +52,33 @@ export function SamlResponseDecoder() {
       {/* Input Card */}
       <Card className="lg:col-span-1">
         <CardContent className="space-y-4 pt-6">
-          <div className="space-y-2">
-            <Label htmlFor="saml-input">SAML Response (Base64)</Label>
+          <div className="space-y-3">
+            <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2">
+              <Label htmlFor="saml-input" className="block text-sm font-medium">
+                SAML Response (Base64)
+              </Label>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleExample}
+                  className="flex items-center gap-1.5"
+                >
+                  <TestTubeDiagonal size={16} />
+                  <span>Example</span>
+                </Button>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={handleClear}
+                  className="flex items-center gap-1.5"
+                >
+                  <RotateCcw size={16} />
+                  <span>Clear</span>
+                </Button>
+              </div>
+            </div>
+            
             <Textarea
               id="saml-input"
               placeholder="Paste your base64-encoded SAML Response here..."
@@ -61,44 +86,24 @@ export function SamlResponseDecoder() {
               onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setInput(e.target.value)}
               className="min-h-[200px] font-mono text-sm"
             />
-          </div>
 
-          {error && (
-            <Alert variant="destructive">
-              <AlertCircle className="h-4 w-4" />
-              <AlertDescription>{error}</AlertDescription>
-            </Alert>
-          )}
+            {error && (
+              <Alert variant="destructive">
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
 
-          <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2 mt-4">
-            <div className="flex flex-wrap gap-2">
+            <div className="flex justify-end">
               <Button
-                variant="outline"
-                size="sm"
-                onClick={handleExample}
-                className="flex items-center gap-1.5"
+                onClick={handleDecode}
+                disabled={!input.trim()}
+                className="w-full sm:w-auto flex items-center gap-1.5"
               >
-                <TestTubeDiagonal size={16} />
-                <span>Example</span>
-              </Button>
-              <Button
-                variant="destructive"
-                size="sm"
-                onClick={handleClear}
-                className="flex items-center gap-1.5"
-              >
-                <RotateCcw size={16} />
-                <span>Clear</span>
+                <Search size={16} />
+                <span>Decode Response</span>
               </Button>
             </div>
-            <Button
-              onClick={handleDecode}
-              disabled={!input.trim()}
-              className="w-full sm:w-auto flex items-center gap-1.5"
-            >
-              <Search size={16} />
-              <span>Decode Response</span>
-            </Button>
           </div>
         </CardContent>
       </Card>

--- a/src/features/tokenInspector/components/TokenInput.tsx
+++ b/src/features/tokenInspector/components/TokenInput.tsx
@@ -4,11 +4,12 @@ import Editor from "react-simple-code-editor";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { InfoIcon } from "lucide-react";
+import { InfoIcon, TestTubeDiagonal, RotateCcw, Search } from "lucide-react";
 import { generateFreshToken } from "../utils/generate-token";
 import { toast } from "sonner";
 import { DEMO_JWKS } from "@/lib/jwt/demo-key";
 import { cn } from "@/lib/utils"; // Import cn utility
+import { TokenHistory } from "./TokenHistory";
 
 interface TokenInputProps {
   token: string;
@@ -17,6 +18,7 @@ interface TokenInputProps {
   onReset: () => void;
   onJwksResolved?: (jwks: any) => void; // Optional callback for JWKS
   initialToken?: string | null; // Token from URL parameter
+  onSelectTokenFromHistory?: (token: string) => void; // Callback for when a token is selected from history
 }
 
 // Highlighting function for JWT parts
@@ -45,7 +47,8 @@ export function TokenInput({
   onDecode, 
   onReset,
   onJwksResolved,
-  initialToken
+  initialToken,
+  onSelectTokenFromHistory
 }: TokenInputProps) {
   const [isLoadingExample, setIsLoadingExample] = useState(false);
   const [isExampleToken, setIsExampleToken] = useState(false);
@@ -60,14 +63,12 @@ export function TokenInput({
     }
   }, [initialToken, token]);
 
-  const handlePaste = async () => {
-    try {
-      const clipboardText = await navigator.clipboard.readText();
-      setToken(clipboardText.trim());
-      setIsExampleToken(false);
-    } catch (err) {
-      console.error("Failed to read clipboard:", err);
-      alert("Unable to access clipboard. Please paste the token manually.");
+  const handleSelectTokenFromHistory = (selectedToken: string) => {
+    setToken(selectedToken);
+    setIsExampleToken(false);
+    setIsInitialToken(false);
+    if (onSelectTokenFromHistory) {
+      onSelectTokenFromHistory(selectedToken);
     }
   };
 
@@ -134,27 +135,27 @@ export function TokenInput({
           OAuth/OIDC Token
         </label>
         <div className="flex flex-wrap gap-2">
-          <Button 
-            variant="outline" 
-            size="sm" 
-            onClick={handlePaste}
-          >
-            Paste
-          </Button>
+          <div className="w-auto">
+            <TokenHistory onSelectToken={handleSelectTokenFromHistory} />
+          </div>
           <Button
             variant="outline"
             size="sm"
             onClick={loadExampleToken}
             disabled={isLoadingExample}
+            className="flex items-center gap-1.5"
           >
-            {isLoadingExample ? "Loading..." : "Example"}
+            <TestTubeDiagonal size={16} />
+            <span>{isLoadingExample ? "Loading..." : "Example"}</span>
           </Button>
           <Button 
             variant="destructive" 
             size="sm" 
             onClick={handleReset}
+            className="flex items-center gap-1.5"
           >
-            Reset
+            <RotateCcw size={16} />
+            <span>Clear</span>
           </Button>
         </div>
       </div>
@@ -214,9 +215,10 @@ export function TokenInput({
         <Button 
           onClick={onDecode}
           disabled={!token}
-          className="w-auto"
+          className="w-auto flex items-center gap-1.5"
         >
-          Inspect Token
+          <Search size={16} />
+          <span>Inspect Token</span>
         </Button>
       </div>
     </div>

--- a/src/features/tokenInspector/components/index.ts
+++ b/src/features/tokenInspector/components/index.ts
@@ -5,4 +5,3 @@ export * from './TokenPayload';
 export * from './TokenSignature';
 export * from './TokenSize';
 export * from './TokenTimeline';
-export * from './TokenHistory';

--- a/src/features/tokenInspector/index.tsx
+++ b/src/features/tokenInspector/index.tsx
@@ -14,8 +14,7 @@ import {
   TokenPayload,
   TokenSignature,
   TokenTimeline,
-  TokenSize,
-  TokenHistory 
+  TokenSize
 } from "./components";
 import { validateToken, determineTokenType } from "./utils/token-validation";
 import type { TokenType, DecodedToken, ValidationResult } from "@/types"; // Point to the shared types directory
@@ -284,20 +283,16 @@ export function TokenInspector({ initialToken = null }: TokenInspectorProps) {
       {/* Input Card */}
       <Card className="lg:col-span-1">
         <CardContent className="p-5">
-          <div className="space-y-4">
-            {/* Token History Component */}
-            <TokenHistory onSelectToken={handleSelectToken} />
-            
-            {/* Token Input Component */}
-            <TokenInput
-              token={token}
-              setToken={setToken} // Let input component update token state
-              onDecode={() => decodeToken(token)} // Explicitly trigger decode on button click
-              onReset={resetState}
-              onJwksResolved={handleJwksFromExample} // For auto-loading JWKS from example btn
-              initialToken={initialToken} // Pass initial token if present
-            />
-          </div>
+          {/* Token Input Component with integrated history */}
+          <TokenInput
+            token={token}
+            setToken={setToken} // Let input component update token state
+            onDecode={() => decodeToken(token)} // Explicitly trigger decode on button click
+            onReset={resetState}
+            onJwksResolved={handleJwksFromExample} // For auto-loading JWKS from example btn
+            initialToken={initialToken} // Pass initial token if present
+            onSelectTokenFromHistory={handleSelectToken} // Pass the callback for history selection
+          />
         </CardContent>
       </Card>
 


### PR DESCRIPTION
- Remove paste button to streamline the interface
- Add icons to buttons for better visual clarity:
  - TestTubeDiagonal icon for Example button
  - RotateCcw icon for Clear button (renamed from Reset)
  - Search icon for Inspect Token button
- Move Recent Tokens dropdown into main button group where paste button was
- Remove standalone TokenHistory component from main layout for cleaner organization
- Update TokenInput to accept history selection callback

This creates a more cohesive and intuitive button layout with better visual indicators.

🤖 Generated with [Claude Code](https://claude.ai/code)