### PR TITLE
fix: consolidate IsPassive in SAML request builder

### DIFF
--- a/src/features/saml/pages/request-builder/index.tsx
+++ b/src/features/saml/pages/request-builder/index.tsx
@@ -213,7 +213,10 @@ export default function SamlRequestBuilderPage() {
             </div>
             <div className="grid gap-2 min-w-0">
               <label className="text-sm">IsPassive</label>
-              <Select value={isPassive} onValueChange={setIsPassive}>
+              <Select
+                value={isPassive}
+                onValueChange={(v: 'unset' | 'true' | 'false') => setIsPassive(v)}
+              >
                 <SelectTrigger className="w-full">
                   <SelectValue placeholder="Not included" />
                 </SelectTrigger>


### PR DESCRIPTION
## Summary
- consolidate `Include IsPassive`/`IsPassive` toggles into one dropdown
- ensure IsPassive control doesn't overflow on small screens

## Testing
- `bun test`
- `bun run lint` *(fails: 162 problems (146 errors, 16 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68b854799890832f8b1e76b3b9def8c6