### PR TITLE
fix: Implement OAuth preflight, harden demo tokens, and fix lint issues

### DIFF
--- a/.github/workflows/bun-tests.yml
+++ b/.github/workflows/bun-tests.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Run lint
+        run: bun run lint
+
       - name: Build application
         run: bun run build
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -166,3 +166,12 @@ IAM Tools also ships a demo OAuth/OIDC provider for local testing and the OAuth 
 - `POST /api/revoke` (always returns 200)
 
 The demo token endpoints accept an optional `claims` JSON object; reserved standard claims are ignored.
+
+### Demo Token/Auth Code Integrity
+
+- Access tokens and ID tokens are JWTs signed with the demo RSA key.
+- `/api/userinfo` and `/api/introspect` verify signature integrity for demo-issued JWTs before treating them as active.
+- Authorization codes and refresh tokens operate in two modes:
+  - Compatibility mode (default): legacy unsigned payload encoding.
+  - Strict mode (`DEMO_TOKEN_SIGNING_SECRET` set): HMAC-signed envelopes in `v1.<payload>.<sig>` format.
+- In strict mode, tampered or legacy-form auth codes/refresh tokens are rejected with OAuth errors (`invalid_grant` for token exchange).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -24,6 +24,7 @@ No special environment variables are required for basic deployment. However, you
 - **NODE_ENV**: Set to `production` for production builds
 - **CORS_ALLOWED_ORIGINS**: Comma-separated list of allowed origins for CORS (disallowed origins receive `403`)
 - **APP_VERSION**: Release version string embedded in the frontend (defaults to package.json version)
+- **DEMO_TOKEN_SIGNING_SECRET**: Optional secret used to HMAC-sign demo authorization codes and refresh tokens (`v1.<payload>.<sig>`). When set, strict verification is enforced for these artifacts.
 
 ### Custom Domains
 
@@ -128,7 +129,9 @@ The deployment includes several security measures:
 3. API request validation in function handlers
 4. Strict allow-listing for the CORS proxy (well-known/JWKS endpoints, `GET/HEAD` only)
 5. In-worker rate limiting on `/api/cors-proxy` and demo OAuth endpoints (`429` with `Retry-After`)
-6. Regular security updates through GitHub dependency management
+6. Signed envelope integrity for demo auth codes/refresh tokens when `DEMO_TOKEN_SIGNING_SECRET` is configured
+7. Demo JWT signature checks in `/api/userinfo` and `/api/introspect` before treating tokens as active
+8. Regular security updates through GitHub dependency management
 
 ## Performance Optimizations
 

--- a/docs/feature-guides/oauth-playground.md
+++ b/docs/feature-guides/oauth-playground.md
@@ -13,6 +13,7 @@ The OAuth Playground is a feature that allows users to test and explore OAuth 2.
 - PKCE code generation and verification
 - Integration with the Token Inspector for examining received tokens
 - Token introspection (RFC 7662) with demo mode support
+- OIDC endpoint preflight checks on all OAuth pages (Auth Code, Client Credentials, Introspection, UserInfo)
 
 ## How to Use
 
@@ -70,6 +71,7 @@ The Token Introspection feature allows you to inspect and validate access tokens
    - **Demo Mode**: Enable demo mode to use a simulated Identity Provider.
    - Configure client ID, redirect URI, and scopes.
    - View and manage PKCE parameters (code verifier, code challenge).
+   - Run **Endpoint Preflight** to validate discovery and endpoint reachability before executing a flow.
 
 3. **Authorization**:
    - View the constructed authorization request URL.
@@ -93,6 +95,19 @@ In real IdP mode, the OAuth Playground:
 4. Receives the authorization code via the callback endpoint.
 5. Exchanges the code for tokens using your IdP's token endpoint.
 6. Displays and allows inspection of the received tokens.
+
+### Endpoint Preflight Workflow
+
+Endpoint preflight is available on all OAuth pages and runs a safe set of checks:
+
+1. Normalize issuer URL and resolve `/.well-known/openid-configuration`.
+2. Validate that key endpoints are published by discovery.
+3. Probe endpoint reachability with non-destructive requests.
+4. Return per-endpoint status:
+   - `pass`: endpoint is reachable/behaving as expected.
+   - `warn`: endpoint reachable but with caveats (auth enforcement, CORS/network limits, probe-method mismatch).
+   - `fail`: endpoint missing, malformed, or clearly unavailable.
+5. Review the inline summary or copy the JSON report for troubleshooting.
 
 ### Demo Mode
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -81,6 +81,7 @@ See [file-structure.md](./file-structure.md) for a more detailed breakdown.
 This project doesn't require any environment variables for basic development. However, if you're deploying your own instance, you may want to configure:
 
 - `CORS_ALLOWED_ORIGINS` - Comma-separated allowlist for API origins (disallowed origins receive `403`)
+- `DEMO_TOKEN_SIGNING_SECRET` - Enables strict signed demo auth-code and refresh-token envelopes (`v1.<payload>.<sig>`)
 
 ## Working with Features
 
@@ -91,6 +92,7 @@ The application currently includes these main features:
 1. **Token Inspector** - For analyzing JWT tokens
 2. **OIDC Explorer** - For exploring OpenID Connect configurations
 3. **CORS Proxy** - For accessing external APIs with CORS restrictions
+4. **OAuth Endpoint Preflight** - For checking OIDC discovery and endpoint reachability before running flows
 
 ### Creating a New Feature
 

--- a/e2e/tests/oauth-playground-auth-code.e2e.ts
+++ b/e2e/tests/oauth-playground-auth-code.e2e.ts
@@ -15,6 +15,25 @@ test.describe('OAuth Playground - Auth Code with PKCE', () => {
     await expect(page.locator('text=OAuth Authorization Code Flow')).toBeVisible()
   })
 
+  test('should run endpoint preflight and continue auth flow', async ({ page }) => {
+    const issuerInput = page.locator('#issuer-url-discovery')
+    await issuerInput.fill('http://localhost:8788/api')
+
+    await page.click('button:has-text("Run Preflight")')
+    await expect(page.locator('text=OIDC Endpoint Preflight')).toBeVisible()
+    await expect(page.locator('text=Raw Report JSON')).toBeVisible()
+
+    const tokenEndpointInput = page.locator('input[placeholder="https://example.com/token"]')
+    await expect(tokenEndpointInput).toHaveValue(/\/api\/token$/)
+
+    const clientIdInput = page.locator(selectors.oauthPlayground.clientIdInput)
+    await clientIdInput.fill('test-client')
+    await page.click('button:has-text("Continue to Authorization")')
+
+    const step2Tab = page.locator('[role="tab"]:has-text("2. AuthZ")')
+    await expect(step2Tab).toHaveAttribute('aria-selected', 'true')
+  })
+
   test('should toggle demo mode', async ({ page }) => {
     // Find demo mode switch
     const demoSwitch = page.locator(selectors.oauthPlayground.demoModeSwitch)

--- a/e2e/tests/oauth-playground-client-credentials.e2e.ts
+++ b/e2e/tests/oauth-playground-client-credentials.e2e.ts
@@ -15,6 +15,22 @@ test.describe('OAuth Playground - Client Credentials', () => {
     await expect(page.locator('text=OAuth Client Credentials Flow')).toBeVisible()
   })
 
+  test('should run token endpoint preflight for reachable and unreachable issuers', async ({
+    page,
+  }) => {
+    const preflightIssuerInput = page.locator('input[placeholder="https://example.com"]').first()
+    await preflightIssuerInput.fill('http://localhost:8788/api')
+    await page.click('button:has-text("Run Preflight")')
+
+    await expect(page.locator('text=Token Endpoint Preflight')).toBeVisible()
+    await expect(page.locator('text=Raw Report JSON')).toBeVisible()
+    await expect(page.locator('#token-endpoint')).toHaveValue(/\/api\/token$/)
+
+    await preflightIssuerInput.fill('http://localhost:8788/api/not-real')
+    await page.click('button:has-text("Run Preflight")')
+    await expect(page.getByText('FAIL').first()).toBeVisible()
+  })
+
   test('should toggle demo mode', async ({ page }) => {
     // Find demo mode switch
     const demoSwitch = page.locator(selectors.oauthPlayground.demoModeSwitch)

--- a/e2e/tests/oauth-playground-preflight-endpoints.e2e.ts
+++ b/e2e/tests/oauth-playground-preflight-endpoints.e2e.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test'
+import { TestUtils } from '../helpers/test-utils'
+
+test.describe('OAuth Playground Endpoint Preflight', () => {
+  let utils: TestUtils
+
+  test.beforeEach(async ({ page }) => {
+    utils = new TestUtils(page)
+  })
+
+  test('should run introspection preflight and validate endpoint before submit', async ({
+    page,
+  }) => {
+    await utils.navigateTo('/oauth-playground/introspection')
+
+    const preflightIssuerInput = page.locator('input[placeholder="https://example.com"]').first()
+    await preflightIssuerInput.fill('http://localhost:8788/api')
+    await page.click('button:has-text("Run Preflight")')
+
+    await expect(page.locator('text=Raw Report JSON')).toBeVisible()
+    await expect(page.locator('#introspection-endpoint')).toHaveValue(/\/api\/introspect$/)
+
+    await page.locator('#token').fill('invalid.token.value')
+    await page.click('button:has-text("Introspect Token")')
+    await expect(page.locator('text=Introspection Result')).toBeVisible()
+  })
+
+  test('should run userinfo preflight and validate endpoint before submit', async ({ page }) => {
+    await utils.navigateTo('/oauth-playground/userinfo')
+
+    const preflightIssuerInput = page.locator('input[placeholder="https://example.com"]').first()
+    await preflightIssuerInput.fill('http://localhost:8788/api')
+    await page.click('button:has-text("Run Preflight")')
+
+    await expect(page.locator('text=Raw Report JSON')).toBeVisible()
+    await expect(page.locator('#userinfo-endpoint')).toHaveValue(/\/api\/userinfo$/)
+
+    await page.locator('#access-token').fill('invalid.token.value')
+    await page.click('button:has-text("Get UserInfo")')
+    await expect(page.locator('text=UserInfo Result')).toBeVisible()
+  })
+})

--- a/scripts/generate-csp-hash.ts
+++ b/scripts/generate-csp-hash.ts
@@ -20,16 +20,15 @@ async function main() {
     matches.push(m[1])
   }
 
-  let scriptContent = ''
   if (matches.length === 0) {
     await writeFile(outPath, `export const CSP_INLINE_SCRIPT_SHA256 = ''\n`)
     console.warn('[generate-csp-hash] No inline <script> found in index.html; wrote empty hash')
     return
-  } else if (matches.length === 1) {
-    scriptContent = matches[0]
-  } else {
-    scriptContent = matches.find((s) => s.includes('iam-tools-theme')) || matches[0]
   }
+  const scriptContent =
+    matches.length === 1
+      ? matches[0]
+      : matches.find((s) => s.includes('iam-tools-theme')) || matches[0]
 
   const hashBase64 = createHash('sha256').update(scriptContent, 'utf8').digest('base64')
   const value = `sha256-${hashBase64}`

--- a/src/features/oauthPlayground/components/ClientCredentialsFlow.tsx
+++ b/src/features/oauthPlayground/components/ClientCredentialsFlow.tsx
@@ -30,6 +30,11 @@ import {
 import { cn } from '@/lib/utils'
 import { Clock, Hash, Layers, ShieldCheck } from 'lucide-react'
 import { ButtonGroup } from '@/components/ui/button-group'
+import EndpointPreflightPanel from './EndpointPreflightPanel'
+import {
+  extractDiscoveredEndpoints,
+  fetchOidcDiscoveryConfiguration,
+} from '../utils/oidc-preflight'
 
 interface TokenResponse {
   access_token?: string
@@ -44,6 +49,7 @@ interface TokenResponse {
 export function ClientCredentialsFlow() {
   const navigate = useNavigate() // Instantiate useNavigate
   const { addIssuer } = useIssuerHistory()
+  const [issuerUrl, setIssuerUrl] = useState('')
   const [tokenEndpoint, setTokenEndpoint] = useState('')
   const [clientId, setClientId] = useState('')
   const [clientSecret, setClientSecret] = useState('')
@@ -74,32 +80,19 @@ export function ClientCredentialsFlow() {
 
   // Handle issuer selection from history
   const handleSelectIssuer = async (issuerUrl: string) => {
+    setIssuerUrl(issuerUrl)
     setConfigLoading(true)
 
     try {
-      // Construct the well-known URL
-      const url = new URL(issuerUrl)
-      const basePath = url.pathname.endsWith('/') ? url.pathname : `${url.pathname}/`
-      const wellKnownUrl = new URL(
-        `${basePath}.well-known/openid-configuration`,
-        url.origin
-      ).toString()
+      const { config, normalizedIssuerUrl } = await fetchOidcDiscoveryConfiguration(issuerUrl)
+      const endpoints = extractDiscoveredEndpoints(config)
+      setIssuerUrl(normalizedIssuerUrl)
 
-      // Fetch OIDC configuration to get token endpoint
-      const response = await proxyFetch(wellKnownUrl)
-
-      if (response.ok) {
-        const config = await response.json()
-        if (config.token_endpoint) {
-          setTokenEndpoint(config.token_endpoint)
-          // Add issuer to history
-          addIssuer(issuerUrl)
-        } else {
-          // Show error if no token endpoint is available
-          toast.error('This issuer does not have a token endpoint configured')
-        }
+      if (endpoints.tokenEndpoint) {
+        setTokenEndpoint(endpoints.tokenEndpoint)
+        addIssuer(normalizedIssuerUrl)
       } else {
-        toast.error('Failed to fetch OIDC configuration')
+        toast.error('This issuer does not have a token endpoint configured')
       }
     } catch (error) {
       toast.error('Error fetching OIDC configuration: ' + (error as Error).message)
@@ -343,6 +336,24 @@ export function ClientCredentialsFlow() {
                 </InputGroupAddon>
               )}
             </InputGroup>
+
+            {!isDemoMode && (
+              <EndpointPreflightPanel
+                issuerUrl={issuerUrl}
+                onIssuerUrlChange={setIssuerUrl}
+                requiredEndpoints={['token_endpoint']}
+                onConfigResolved={(config, normalizedIssuerUrl) => {
+                  const endpoints = extractDiscoveredEndpoints(config)
+                  setIssuerUrl(normalizedIssuerUrl)
+                  if (endpoints.tokenEndpoint) {
+                    setTokenEndpoint(endpoints.tokenEndpoint)
+                    addIssuer(normalizedIssuerUrl)
+                  }
+                }}
+                title="Token Endpoint Preflight"
+                description="Run OIDC discovery and endpoint probes before requesting a token."
+              />
+            )}
 
             <FieldSet className="space-y-4 rounded-md border border-border p-4">
               <FieldLegend>Client Authentication</FieldLegend>

--- a/src/features/oauthPlayground/components/ConfigurationForm.tsx
+++ b/src/features/oauthPlayground/components/ConfigurationForm.tsx
@@ -338,7 +338,6 @@ export function ConfigurationForm({ onConfigComplete }: ConfigurationFormProps) 
                     clearDiscoveredEndpoints()
                   }}
                   showIssuerInput={false}
-                  title="Endpoint Preflight"
                   description="Run endpoint probes with the issuer URL above before starting the flow."
                   onConfigResolved={(config, normalizedIssuerUrl) => {
                     const hasUsableEndpoints = applyDiscoveredConfiguration(

--- a/src/features/oauthPlayground/components/ConfigurationForm.tsx
+++ b/src/features/oauthPlayground/components/ConfigurationForm.tsx
@@ -337,6 +337,9 @@ export function ConfigurationForm({ onConfigComplete }: ConfigurationFormProps) 
                     setIssuerUrl(value)
                     clearDiscoveredEndpoints()
                   }}
+                  showIssuerInput={false}
+                  title="Endpoint Preflight"
+                  description="Run endpoint probes with the issuer URL above before starting the flow."
                   onConfigResolved={(config, normalizedIssuerUrl) => {
                     const hasUsableEndpoints = applyDiscoveredConfiguration(
                       config,

--- a/src/features/oauthPlayground/components/ConfigurationForm.tsx
+++ b/src/features/oauthPlayground/components/ConfigurationForm.tsx
@@ -7,13 +7,18 @@ import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/in
 import { Spinner } from '@/components/ui/spinner'
 import { FieldSet, FieldLegend, FieldDescription } from '@/components/ui/field'
 import { generateCodeVerifier, generateCodeChallenge, generateState } from '../utils/pkce'
-import { proxyFetch } from '@/lib/proxy-fetch'
 import { OAuthConfig, PkceParams } from '../utils/types' // Removed OAuthFlowType import
 import { getIssuerBaseUrl } from '@/lib/jwt/generate-signed-token'
 import { toast } from 'sonner'
 import { IssuerHistory, FormFieldInput, DemoModeToggle } from '@/components/common'
 import { useIssuerHistory } from '@/lib/state'
 import { Label } from '@/components/ui/label'
+import type { OidcConfiguration } from '@/features/oidcExplorer/utils/types'
+import EndpointPreflightPanel from './EndpointPreflightPanel'
+import {
+  extractDiscoveredEndpoints,
+  fetchOidcDiscoveryConfiguration,
+} from '../utils/oidc-preflight'
 
 interface ConfigurationFormProps {
   onConfigComplete: (config: OAuthConfig, pkce: PkceParams) => void
@@ -51,16 +56,35 @@ export function ConfigurationForm({ onConfigComplete }: ConfigurationFormProps) 
     }
   }, [isDemoMode])
 
-  // Handle selecting an issuer from the history
-  const handleSelectIssuer = (issuerUrl: string) => {
-    setIssuerUrl(issuerUrl)
-    // Clear endpoints when issuer changes
+  const clearDiscoveredEndpoints = () => {
     setAuthEndpoint('')
     setTokenEndpoint('')
     setJwksEndpoint('')
     setEndpointsLocked(false)
-    // Fetch config from the selected issuer
-    setTimeout(() => fetchOidcConfig(), 0)
+  }
+
+  const applyDiscoveredConfiguration = (
+    config: Partial<OidcConfiguration>,
+    normalizedIssuerUrl: string
+  ) => {
+    const endpoints = extractDiscoveredEndpoints(config)
+    setAuthEndpoint(endpoints.authorizationEndpoint ?? '')
+    setTokenEndpoint(endpoints.tokenEndpoint ?? '')
+    setJwksEndpoint(endpoints.jwksEndpoint ?? '')
+    setIssuerUrl(normalizedIssuerUrl)
+
+    const hasUsableEndpoints = Boolean(
+      endpoints.authorizationEndpoint || endpoints.tokenEndpoint || endpoints.jwksEndpoint
+    )
+
+    if (hasUsableEndpoints) {
+      setEndpointsLocked(true)
+      addIssuer(normalizedIssuerUrl)
+    } else {
+      setEndpointsLocked(false)
+    }
+
+    return hasUsableEndpoints
   }
 
   const regeneratePkce = async () => {
@@ -74,34 +98,23 @@ export function ConfigurationForm({ onConfigComplete }: ConfigurationFormProps) 
     setState(newState)
   }
 
-  const fetchOidcConfig = async () => {
-    if (!issuerUrl) {
+  const fetchOidcConfig = async (issuerInput = issuerUrl) => {
+    const targetIssuer = issuerInput.trim()
+    if (!targetIssuer) {
       toast.error('Please enter an issuer URL')
       return
     }
 
     setIsLoadingDiscovery(true)
     try {
-      const discoveryUrl = issuerUrl.endsWith('/')
-        ? `${issuerUrl}.well-known/openid-configuration`
-        : `${issuerUrl}/.well-known/openid-configuration`
+      const { config, normalizedIssuerUrl } = await fetchOidcDiscoveryConfiguration(targetIssuer)
+      const hasUsableEndpoints = applyDiscoveredConfiguration(config, normalizedIssuerUrl)
 
-      const response = await proxyFetch(discoveryUrl)
-      const config = await response.json()
-
-      if (config.authorization_endpoint) setAuthEndpoint(config.authorization_endpoint)
-      if (config.authorization_endpoint) setAuthEndpoint(config.authorization_endpoint)
-      if (config.token_endpoint) setTokenEndpoint(config.token_endpoint)
-      if (config.jwks_uri) setJwksEndpoint(config.jwks_uri)
-
-      // Lock endpoints if discovery was successful
-      if (config.authorization_endpoint || config.token_endpoint || config.jwks_uri) {
-        setEndpointsLocked(true)
-        // Add to issuer history if discovery was successful
-        addIssuer(issuerUrl)
+      if (hasUsableEndpoints) {
+        toast.success('OIDC configuration loaded successfully')
+      } else {
+        toast.error('Discovery succeeded but no usable OAuth endpoints were returned')
       }
-
-      toast.success('OIDC configuration loaded successfully')
     } catch (error) {
       setEndpointsLocked(false) // Unlock on error
       if (import.meta?.env?.DEV) {
@@ -111,6 +124,13 @@ export function ConfigurationForm({ onConfigComplete }: ConfigurationFormProps) 
     } finally {
       setIsLoadingDiscovery(false)
     }
+  }
+
+  // Handle selecting an issuer from the history
+  const handleSelectIssuer = (selectedIssuerUrl: string) => {
+    setIssuerUrl(selectedIssuerUrl)
+    clearDiscoveredEndpoints()
+    void fetchOidcConfig(selectedIssuerUrl)
   }
 
   const handleSubmit = () => {
@@ -186,129 +206,150 @@ export function ConfigurationForm({ onConfigComplete }: ConfigurationFormProps) 
           {/* Configuration based on mode */}
           {
             !isDemoMode ? (
-              <FieldSet className="space-y-4 rounded-lg border border-border p-4">
-                <FieldLegend>Identity Provider Details</FieldLegend>
-                {/* Issuer URL for Auto-Discovery */}
-                <div className="space-y-2">
-                  <InputGroup className="flex-wrap">
-                    <InputGroupAddon
-                      align="block-start"
-                      className="flex w-full flex-wrap items-center justify-between gap-2 border-0 bg-transparent pb-1"
-                    >
-                      <Label
-                        htmlFor="issuer-url-discovery"
-                        className="text-sm font-medium text-foreground"
+              <>
+                <FieldSet className="space-y-4 rounded-lg border border-border p-4">
+                  <FieldLegend>Identity Provider Details</FieldLegend>
+                  {/* Issuer URL for Auto-Discovery */}
+                  <div className="space-y-2">
+                    <InputGroup className="flex-wrap">
+                      <InputGroupAddon
+                        align="block-start"
+                        className="flex w-full flex-wrap items-center justify-between gap-2 border-0 bg-transparent pb-1"
                       >
-                        Issuer URL (for Auto-Discovery)
-                      </Label>
-                      <IssuerHistory
-                        onSelectIssuer={handleSelectIssuer}
-                        compact
-                        label="Recents"
-                        buttonVariant="input-group"
-                        configLoading={isLoadingDiscovery}
-                      />
-                    </InputGroupAddon>
-                    <div data-slot="input-group-control" className="w-full px-3 pb-3 pt-0">
-                      <InputGroupInput
-                        id="issuer-url-discovery"
-                        placeholder="https://example.com"
-                        value={issuerUrl}
-                        onChange={(e) => {
-                          setIssuerUrl(e.target.value)
-                          setAuthEndpoint('')
-                          setTokenEndpoint('')
-                          setJwksEndpoint('')
-                          setEndpointsLocked(false)
-                        }}
-                        className="h-11 rounded-none border-0 bg-transparent px-3 focus-visible:ring-0 focus-visible:ring-offset-0"
-                      />
-                    </div>
-                    <InputGroupAddon
-                      align="block-end"
-                      className="flex w-full justify-end border-0 bg-transparent pt-0 text-foreground"
-                    >
-                      <Button
-                        type="button"
-                        variant="outline"
-                        onClick={fetchOidcConfig}
-                        disabled={isLoadingDiscovery || !issuerUrl}
-                        className="flex items-center gap-2"
+                        <Label
+                          htmlFor="issuer-url-discovery"
+                          className="text-sm font-medium text-foreground"
+                        >
+                          Issuer URL (for Auto-Discovery)
+                        </Label>
+                        <IssuerHistory
+                          onSelectIssuer={handleSelectIssuer}
+                          compact
+                          label="Recents"
+                          buttonVariant="input-group"
+                          configLoading={isLoadingDiscovery}
+                        />
+                      </InputGroupAddon>
+                      <div data-slot="input-group-control" className="w-full px-3 pb-3 pt-0">
+                        <InputGroupInput
+                          id="issuer-url-discovery"
+                          placeholder="https://example.com"
+                          value={issuerUrl}
+                          onChange={(e) => {
+                            setIssuerUrl(e.target.value)
+                            clearDiscoveredEndpoints()
+                          }}
+                          className="h-11 rounded-none border-0 bg-transparent px-3 focus-visible:ring-0 focus-visible:ring-offset-0"
+                        />
+                      </div>
+                      <InputGroupAddon
+                        align="block-end"
+                        className="flex w-full justify-end border-0 bg-transparent pt-0 text-foreground"
                       >
-                        {isLoadingDiscovery ? (
-                          <>
-                            <Spinner size="sm" thickness="thin" aria-hidden="true" />
-                            <span>Discovering…</span>
-                          </>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          onClick={() => {
+                            void fetchOidcConfig()
+                          }}
+                          disabled={isLoadingDiscovery || !issuerUrl}
+                          className="flex items-center gap-2"
+                        >
+                          {isLoadingDiscovery ? (
+                            <>
+                              <Spinner size="sm" thickness="thin" aria-hidden="true" />
+                              <span>Discovering…</span>
+                            </>
+                          ) : (
+                            'Discover'
+                          )}
+                        </Button>
+                      </InputGroupAddon>
+                    </InputGroup>
+                    <FieldDescription className="text-xs text-muted-foreground">
+                      Enter the base URL of your IdP to attempt auto-discovery of endpoints via the
+                      OIDC discovery document.
+                    </FieldDescription>
+                  </div>
+
+                  {/* Manual/Discovered Endpoints */}
+                  <FormFieldInput
+                    label="Authorization Endpoint"
+                    placeholder="https://example.com/authorize"
+                    value={authEndpoint}
+                    onChange={(e) => setAuthEndpoint(e.target.value)}
+                    readOnly={endpointsLocked}
+                    description={
+                      <span className="flex items-center gap-2">
+                        <span>Required endpoint for starting the authorization flow.</span>
+                        {endpointsLocked ? (
+                          <Badge variant="secondary">Auto-discovered</Badge>
                         ) : (
-                          'Discover'
+                          <span>(Enter manually if not discovered)</span>
                         )}
-                      </Button>
-                    </InputGroupAddon>
-                  </InputGroup>
-                  <FieldDescription className="text-xs text-muted-foreground">
-                    Enter the base URL of your IdP to attempt auto-discovery of endpoints via the
-                    OIDC discovery document.
-                  </FieldDescription>
-                </div>
-
-                {/* Manual/Discovered Endpoints */}
-                <FormFieldInput
-                  label="Authorization Endpoint"
-                  placeholder="https://example.com/authorize"
-                  value={authEndpoint}
-                  onChange={(e) => setAuthEndpoint(e.target.value)}
-                  readOnly={endpointsLocked}
-                  description={
-                    <span className="flex items-center gap-2">
-                      <span>Required endpoint for starting the authorization flow.</span>
-                      {endpointsLocked ? (
-                        <Badge variant="secondary">Auto-discovered</Badge>
-                      ) : (
-                        <span>(Enter manually if not discovered)</span>
-                      )}
-                    </span>
-                  }
-                />
-
-                <FormFieldInput
-                  label="Token Endpoint"
-                  placeholder="https://example.com/token"
-                  value={tokenEndpoint}
-                  onChange={(e) => setTokenEndpoint(e.target.value)}
-                  readOnly={endpointsLocked}
-                  description={
-                    <span className="flex items-center gap-2">
-                      <span>
-                        Required endpoint for exchanging the authorization code for tokens.
                       </span>
-                      {endpointsLocked ? (
-                        <Badge variant="secondary">Auto-discovered</Badge>
-                      ) : (
-                        <span>(Enter manually if not discovered)</span>
-                      )}
-                    </span>
-                  }
-                />
+                    }
+                  />
 
-                <FormFieldInput
-                  label="JWKS Endpoint (Optional)"
-                  placeholder="https://example.com/.well-known/jwks.json"
-                  value={jwksEndpoint}
-                  onChange={(e) => setJwksEndpoint(e.target.value)}
-                  readOnly={endpointsLocked}
-                  description={
-                    <span className="flex items-center gap-2">
-                      <span>Endpoint for retrieving public keys to validate token signatures.</span>
-                      {endpointsLocked ? (
-                        <Badge variant="secondary">Auto-discovered</Badge>
-                      ) : (
-                        <span>(Enter manually if not discovered)</span>
-                      )}
-                    </span>
-                  }
+                  <FormFieldInput
+                    label="Token Endpoint"
+                    placeholder="https://example.com/token"
+                    value={tokenEndpoint}
+                    onChange={(e) => setTokenEndpoint(e.target.value)}
+                    readOnly={endpointsLocked}
+                    description={
+                      <span className="flex items-center gap-2">
+                        <span>
+                          Required endpoint for exchanging the authorization code for tokens.
+                        </span>
+                        {endpointsLocked ? (
+                          <Badge variant="secondary">Auto-discovered</Badge>
+                        ) : (
+                          <span>(Enter manually if not discovered)</span>
+                        )}
+                      </span>
+                    }
+                  />
+
+                  <FormFieldInput
+                    label="JWKS Endpoint (Optional)"
+                    placeholder="https://example.com/.well-known/jwks.json"
+                    value={jwksEndpoint}
+                    onChange={(e) => setJwksEndpoint(e.target.value)}
+                    readOnly={endpointsLocked}
+                    description={
+                      <span className="flex items-center gap-2">
+                        <span>
+                          Endpoint for retrieving public keys to validate token signatures.
+                        </span>
+                        {endpointsLocked ? (
+                          <Badge variant="secondary">Auto-discovered</Badge>
+                        ) : (
+                          <span>(Enter manually if not discovered)</span>
+                        )}
+                      </span>
+                    }
+                  />
+                </FieldSet>
+                <EndpointPreflightPanel
+                  issuerUrl={issuerUrl}
+                  onIssuerUrlChange={(value) => {
+                    setIssuerUrl(value)
+                    clearDiscoveredEndpoints()
+                  }}
+                  onConfigResolved={(config, normalizedIssuerUrl) => {
+                    const hasUsableEndpoints = applyDiscoveredConfiguration(
+                      config,
+                      normalizedIssuerUrl
+                    )
+                    if (!hasUsableEndpoints) {
+                      toast.warning(
+                        'Preflight completed, but discovery returned no usable endpoints'
+                      )
+                    }
+                  }}
                 />
-              </FieldSet>
+              </>
             ) : // Removed the empty div that previously held the static message
             null // Or simply remove the entire else block if nothing else goes here
           }

--- a/src/features/oauthPlayground/components/EndpointPreflightPanel.tsx
+++ b/src/features/oauthPlayground/components/EndpointPreflightPanel.tsx
@@ -1,0 +1,161 @@
+import { useMemo, useState } from 'react'
+import { toast } from 'sonner'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { FormFieldInput } from '@/components/common'
+import { JsonDisplay } from '@/components/common/JsonDisplay'
+import { CopyButton } from '@/components/common/CopyButton'
+import type { OidcConfiguration } from '@/features/oidcExplorer/utils/types'
+import {
+  OidcEndpointName,
+  OidcEndpointPreflightResult,
+  OidcPreflightReport,
+  runOidcEndpointPreflight,
+} from '../utils/oidc-preflight'
+
+interface EndpointPreflightPanelProps {
+  issuerUrl: string
+  onIssuerUrlChange: (value: string) => void
+  requiredEndpoints?: OidcEndpointName[]
+  onConfigResolved?: (config: OidcConfiguration, normalizedIssuerUrl: string) => void
+  title?: string
+  description?: string
+}
+
+function getStatusVariant(status: OidcEndpointPreflightResult['status']) {
+  switch (status) {
+    case 'pass':
+      return 'bg-green-500/15 text-green-700 dark:text-green-300'
+    case 'warn':
+      return 'bg-amber-500/15 text-amber-700 dark:text-amber-300'
+    default:
+      return 'bg-red-500/15 text-red-700 dark:text-red-300'
+  }
+}
+
+export function EndpointPreflightPanel({
+  issuerUrl,
+  onIssuerUrlChange,
+  requiredEndpoints,
+  onConfigResolved,
+  title = 'OIDC Endpoint Preflight',
+  description = 'Check discovery and key endpoints before running OAuth flows.',
+}: EndpointPreflightPanelProps) {
+  const [report, setReport] = useState<OidcPreflightReport | null>(null)
+  const [isRunning, setIsRunning] = useState(false)
+
+  const summaryText = useMemo(() => {
+    if (!report) return null
+    const { pass, warn, fail } = report.summary
+    return `pass ${pass} · warn ${warn} · fail ${fail}`
+  }, [report])
+
+  const handleRunPreflight = async () => {
+    if (!issuerUrl.trim()) {
+      toast.error('Issuer URL is required for preflight')
+      return
+    }
+
+    setIsRunning(true)
+    try {
+      const preflightReport = await runOidcEndpointPreflight({
+        issuerUrl,
+        requiredEndpoints,
+      })
+
+      setReport(preflightReport)
+      if (preflightReport.config && onConfigResolved) {
+        onConfigResolved(preflightReport.config, preflightReport.normalizedIssuerUrl)
+      }
+
+      if (preflightReport.summary.fail > 0) {
+        toast.error('Endpoint preflight finished with failures')
+      } else if (preflightReport.summary.warn > 0) {
+        toast.warning('Endpoint preflight finished with warnings')
+      } else {
+        toast.success('Endpoint preflight passed')
+      }
+    } catch (error) {
+      setReport(null)
+      toast.error(
+        error instanceof Error ? error.message : 'Failed to run endpoint preflight checks'
+      )
+    } finally {
+      setIsRunning(false)
+    }
+  }
+
+  return (
+    <Card className="border-dashed">
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <FormFieldInput
+          label="Issuer URL"
+          placeholder="https://example.com"
+          value={issuerUrl}
+          onChange={(event) => onIssuerUrlChange(event.target.value)}
+          description="Used to resolve /.well-known/openid-configuration and probe endpoint reachability."
+        />
+
+        <div className="flex items-center gap-2">
+          <Button type="button" variant="outline" onClick={handleRunPreflight} disabled={isRunning}>
+            {isRunning ? 'Running preflight…' : 'Run Preflight'}
+          </Button>
+          {report && (
+            <CopyButton
+              text={JSON.stringify(report, null, 2)}
+              variant="outline"
+              size="sm"
+              copiedText="Report copied"
+            />
+          )}
+        </div>
+
+        {report && (
+          <div className="space-y-4">
+            <div className="flex flex-wrap items-center gap-2 text-xs">
+              <Badge variant="outline">
+                Generated: {new Date(report.generatedAt).toLocaleString()}
+              </Badge>
+              {summaryText && <Badge variant="outline">{summaryText}</Badge>}
+              <Badge variant="outline">Issuer: {report.normalizedIssuerUrl}</Badge>
+            </div>
+
+            <div className="space-y-2">
+              {report.endpoints.map((result) => (
+                <div key={result.endpoint} className="rounded-md border bg-muted/20 p-3">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm font-medium">{result.label}</span>
+                    <Badge variant="outline" className={getStatusVariant(result.status)}>
+                      {result.status.toUpperCase()}
+                    </Badge>
+                    <Badge variant="outline">{result.method}</Badge>
+                    {typeof result.httpStatus === 'number' && (
+                      <Badge variant="outline">HTTP {result.httpStatus}</Badge>
+                    )}
+                  </div>
+                  <p className="mt-2 text-xs text-muted-foreground">{result.message}</p>
+                  {result.url && <p className="mt-1 break-all font-mono text-xs">{result.url}</p>}
+                  {result.error && <p className="mt-1 text-xs text-destructive">{result.error}</p>}
+                </div>
+              ))}
+            </div>
+
+            <details className="rounded-md border bg-muted/10 p-3">
+              <summary className="cursor-pointer text-sm font-medium">Raw Report JSON</summary>
+              <div className="mt-3">
+                <JsonDisplay data={report} containerClassName="relative" maxHeight="320px" />
+              </div>
+            </details>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+export default EndpointPreflightPanel

--- a/src/features/oauthPlayground/components/EndpointPreflightPanel.tsx
+++ b/src/features/oauthPlayground/components/EndpointPreflightPanel.tsx
@@ -21,6 +21,7 @@ interface EndpointPreflightPanelProps {
   onConfigResolved?: (config: OidcConfiguration, normalizedIssuerUrl: string) => void
   title?: string
   description?: string
+  showIssuerInput?: boolean
 }
 
 function getStatusVariant(status: OidcEndpointPreflightResult['status']) {
@@ -41,6 +42,7 @@ export function EndpointPreflightPanel({
   onConfigResolved,
   title = 'OIDC Endpoint Preflight',
   description = 'Check discovery and key endpoints before running OAuth flows.',
+  showIssuerInput = true,
 }: EndpointPreflightPanelProps) {
   const [report, setReport] = useState<OidcPreflightReport | null>(null)
   const [isRunning, setIsRunning] = useState(false)
@@ -93,13 +95,15 @@ export function EndpointPreflightPanel({
         <CardDescription>{description}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <FormFieldInput
-          label="Issuer URL"
-          placeholder="https://example.com"
-          value={issuerUrl}
-          onChange={(event) => onIssuerUrlChange(event.target.value)}
-          description="Used to resolve /.well-known/openid-configuration and probe endpoint reachability."
-        />
+        {showIssuerInput ? (
+          <FormFieldInput
+            label="Issuer URL"
+            placeholder="https://example.com"
+            value={issuerUrl}
+            onChange={(event) => onIssuerUrlChange(event.target.value)}
+            description="Used to resolve /.well-known/openid-configuration and probe endpoint reachability."
+          />
+        ) : null}
 
         <div className="flex items-center gap-2">
           <Button type="button" variant="outline" onClick={handleRunPreflight} disabled={isRunning}>

--- a/src/features/oauthPlayground/components/TokenIntrospection.tsx
+++ b/src/features/oauthPlayground/components/TokenIntrospection.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { Badge } from '@/components/ui/badge'
-import { useAppState } from '@/lib/state'
+import { useAppState, useIssuerHistory } from '@/lib/state'
 import { CheckCircle, XCircle } from 'lucide-react'
 import { proxyFetch } from '@/lib/proxy-fetch'
 import { getIssuerBaseUrl } from '@/lib/jwt/generate-signed-token'
@@ -35,6 +35,11 @@ import {
   ItemTitle,
 } from '@/components/ui/item'
 import { cn } from '@/lib/utils'
+import EndpointPreflightPanel from './EndpointPreflightPanel'
+import {
+  extractDiscoveredEndpoints,
+  fetchOidcDiscoveryConfiguration,
+} from '../utils/oidc-preflight'
 
 interface IntrospectionResponse {
   active: boolean
@@ -57,8 +62,10 @@ interface IntrospectionResponse {
 export function TokenIntrospection() {
   const navigate = useNavigate()
   const { addToken } = useAppState()
+  const { addIssuer } = useIssuerHistory()
 
   // Endpoint state
+  const [issuerUrl, setIssuerUrl] = useState('')
   const [introspectionEndpoint, setIntrospectionEndpoint] = useState('')
   const [token, setToken] = useState('')
   const [clientId, setClientId] = useState('')
@@ -112,30 +119,19 @@ export function TokenIntrospection() {
 
   // Handle issuer selection from history
   const handleSelectIssuer = async (issuerUrl: string) => {
+    setIssuerUrl(issuerUrl)
     setConfigLoading(true)
 
     try {
-      // Construct the well-known URL
-      const url = new URL(issuerUrl)
-      const basePath = url.pathname.endsWith('/') ? url.pathname : `${url.pathname}/`
-      const wellKnownUrl = new URL(
-        `${basePath}.well-known/openid-configuration`,
-        url.origin
-      ).toString()
+      const { config, normalizedIssuerUrl } = await fetchOidcDiscoveryConfiguration(issuerUrl)
+      const endpoints = extractDiscoveredEndpoints(config)
+      setIssuerUrl(normalizedIssuerUrl)
 
-      // Fetch OIDC configuration to get introspection endpoint
-      const response = await proxyFetch(wellKnownUrl)
-
-      if (response.ok) {
-        const config = await response.json()
-        if (config.introspection_endpoint) {
-          setIntrospectionEndpoint(config.introspection_endpoint)
-        } else {
-          // Show error if no introspection endpoint is available
-          toast.error('This issuer does not have an introspection endpoint configured')
-        }
+      if (endpoints.introspectionEndpoint) {
+        setIntrospectionEndpoint(endpoints.introspectionEndpoint)
+        addIssuer(normalizedIssuerUrl)
       } else {
-        toast.error('Failed to fetch OIDC configuration')
+        toast.error('This issuer does not have an introspection endpoint configured')
       }
     } catch (error) {
       toast.error('Error fetching OIDC configuration: ' + (error as Error).message)
@@ -369,6 +365,24 @@ export function TokenIntrospection() {
                 }
               />
             </InputGroup>
+
+            {!isDemoMode && (
+              <EndpointPreflightPanel
+                issuerUrl={issuerUrl}
+                onIssuerUrlChange={setIssuerUrl}
+                requiredEndpoints={['introspection_endpoint']}
+                onConfigResolved={(config, normalizedIssuerUrl) => {
+                  const endpoints = extractDiscoveredEndpoints(config)
+                  setIssuerUrl(normalizedIssuerUrl)
+                  if (endpoints.introspectionEndpoint) {
+                    setIntrospectionEndpoint(endpoints.introspectionEndpoint)
+                    addIssuer(normalizedIssuerUrl)
+                  }
+                }}
+                title="Introspection Endpoint Preflight"
+                description="Validate discovery and endpoint reachability before introspection."
+              />
+            )}
 
             {/* Token Input with History */}
             <InputGroup className="flex-wrap">

--- a/src/features/oauthPlayground/components/UserInfo.tsx
+++ b/src/features/oauthPlayground/components/UserInfo.tsx
@@ -30,6 +30,11 @@ import {
   ItemMedia,
   ItemTitle,
 } from '@/components/ui/item'
+import EndpointPreflightPanel from './EndpointPreflightPanel'
+import {
+  extractDiscoveredEndpoints,
+  fetchOidcDiscoveryConfiguration,
+} from '../utils/oidc-preflight'
 
 interface UserInfoResponse {
   sub?: string
@@ -70,6 +75,7 @@ export function UserInfo() {
   const { addToken } = useAppState()
 
   // Form state
+  const [issuerUrl, setIssuerUrl] = useState('')
   const [userInfoEndpoint, setUserInfoEndpoint] = useState('')
   const [accessToken, setAccessToken] = useState('')
 
@@ -112,32 +118,19 @@ export function UserInfo() {
 
   // Handle issuer selection from history
   const handleSelectIssuer = async (issuerUrl: string) => {
+    setIssuerUrl(issuerUrl)
     setConfigLoading(true)
 
     try {
-      // Construct the well-known URL
-      const url = new URL(issuerUrl)
-      const basePath = url.pathname.endsWith('/') ? url.pathname : `${url.pathname}/`
-      const wellKnownUrl = new URL(
-        `${basePath}.well-known/openid-configuration`,
-        url.origin
-      ).toString()
+      const { config, normalizedIssuerUrl } = await fetchOidcDiscoveryConfiguration(issuerUrl)
+      const endpoints = extractDiscoveredEndpoints(config)
+      setIssuerUrl(normalizedIssuerUrl)
 
-      // Fetch OIDC configuration to get userinfo endpoint
-      const response = await proxyFetch(wellKnownUrl)
-
-      if (response.ok) {
-        const config = await response.json()
-        if (config.userinfo_endpoint) {
-          setUserInfoEndpoint(config.userinfo_endpoint)
-          // Add issuer to history
-          addIssuer(issuerUrl)
-        } else {
-          // Show error if no userinfo endpoint is available
-          toast.error('This issuer does not have a userinfo endpoint configured')
-        }
+      if (endpoints.userInfoEndpoint) {
+        setUserInfoEndpoint(endpoints.userInfoEndpoint)
+        addIssuer(normalizedIssuerUrl)
       } else {
-        toast.error('Failed to fetch OIDC configuration')
+        toast.error('This issuer does not have a userinfo endpoint configured')
       }
     } catch (error) {
       toast.error('Error fetching OIDC configuration: ' + (error as Error).message)
@@ -357,6 +350,24 @@ export function UserInfo() {
                 </InputGroupAddon>
               )}
             </InputGroup>
+
+            {!isDemoMode && (
+              <EndpointPreflightPanel
+                issuerUrl={issuerUrl}
+                onIssuerUrlChange={setIssuerUrl}
+                requiredEndpoints={['userinfo_endpoint']}
+                onConfigResolved={(config, normalizedIssuerUrl) => {
+                  const endpoints = extractDiscoveredEndpoints(config)
+                  setIssuerUrl(normalizedIssuerUrl)
+                  if (endpoints.userInfoEndpoint) {
+                    setUserInfoEndpoint(endpoints.userInfoEndpoint)
+                    addIssuer(normalizedIssuerUrl)
+                  }
+                }}
+                title="UserInfo Endpoint Preflight"
+                description="Check discovery and UserInfo endpoint behavior before querying claims."
+              />
+            )}
 
             {/* Access Token Input with History */}
             <InputGroup className="flex-wrap">

--- a/src/features/oauthPlayground/utils/oidc-preflight.ts
+++ b/src/features/oauthPlayground/utils/oidc-preflight.ts
@@ -451,8 +451,21 @@ function classifyProbeError(error: unknown): OidcEndpointStatus {
     return 'warn'
   }
 
-  if (error instanceof Error && error.message.toLowerCase().includes('failed to fetch')) {
+  if (error instanceof TypeError) {
     return 'warn'
+  }
+
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase()
+    if (
+      message.includes('failed to fetch') ||
+      message.includes('network') ||
+      message.includes('cors') ||
+      message.includes('load failed') ||
+      message.includes('blocked')
+    ) {
+      return 'warn'
+    }
   }
 
   return 'fail'

--- a/src/features/oauthPlayground/utils/oidc-preflight.ts
+++ b/src/features/oauthPlayground/utils/oidc-preflight.ts
@@ -1,6 +1,8 @@
 import { proxyFetch } from '@/lib/proxy-fetch'
 import type { OidcConfiguration } from '@/features/oidcExplorer/utils/types'
 
+export type OidcFetchFunction = (url: string, options?: RequestInit) => Promise<Response>
+
 export type OidcEndpointName =
   | 'discovery'
   | 'authorization_endpoint'
@@ -113,12 +115,13 @@ export function buildOidcDiscoveryUrl(issuerUrl: string): string {
 }
 
 export async function fetchOidcDiscoveryConfiguration(
-  issuerUrl: string
+  issuerUrl: string,
+  fetcher: OidcFetchFunction = proxyFetch
 ): Promise<OidcDiscoveryFetchResult> {
   const normalizedIssuerUrl = normalizeIssuerUrl(issuerUrl)
   const discoveryUrl = buildOidcDiscoveryUrl(normalizedIssuerUrl)
 
-  const response = await proxyFetch(discoveryUrl)
+  const response = await fetcher(discoveryUrl)
   if (!response.ok) {
     throw new Error(await buildResponseError(response, 'OIDC discovery failed'))
   }
@@ -161,7 +164,8 @@ export function hasUsableDiscoveredEndpoints(config: Partial<OidcConfiguration>)
 }
 
 export async function runOidcEndpointPreflight(
-  request: OidcPreflightRequest
+  request: OidcPreflightRequest,
+  fetcher: OidcFetchFunction = proxyFetch
 ): Promise<OidcPreflightReport> {
   const requiredEndpoints = request.requiredEndpoints?.length
     ? request.requiredEndpoints
@@ -175,7 +179,7 @@ export async function runOidcEndpointPreflight(
 
   let discoveryResult: OidcDiscoveryFetchResult
   try {
-    discoveryResult = await fetchOidcDiscoveryConfiguration(normalizedIssuerUrl)
+    discoveryResult = await fetchOidcDiscoveryConfiguration(normalizedIssuerUrl, fetcher)
     endpoints.push({
       endpoint: 'discovery',
       label: ENDPOINT_LABELS.discovery,
@@ -243,6 +247,7 @@ export async function runOidcEndpointPreflight(
       url: endpointUrl,
       method: ENDPOINT_METHODS[key],
       timeoutMs,
+      fetcher,
     })
 
     endpoints.push(probeResult)
@@ -308,13 +313,14 @@ async function probeEndpoint(input: {
   url: string
   method: 'GET' | 'HEAD' | 'POST'
   timeoutMs: number
+  fetcher: OidcFetchFunction
 }): Promise<OidcEndpointPreflightResult> {
   const controller = new AbortController()
   const timeoutHandle = setTimeout(() => controller.abort(), input.timeoutMs)
 
   try {
     const requestInit = createProbeRequest(input.endpoint, input.method, controller.signal)
-    const response = await proxyFetch(input.url, requestInit)
+    const response = await input.fetcher(input.url, requestInit)
 
     return {
       endpoint: input.endpoint,

--- a/src/features/oauthPlayground/utils/oidc-preflight.ts
+++ b/src/features/oauthPlayground/utils/oidc-preflight.ts
@@ -1,0 +1,453 @@
+import { proxyFetch } from '@/lib/proxy-fetch'
+import type { OidcConfiguration } from '@/features/oidcExplorer/utils/types'
+
+export type OidcEndpointName =
+  | 'discovery'
+  | 'authorization_endpoint'
+  | 'token_endpoint'
+  | 'userinfo_endpoint'
+  | 'introspection_endpoint'
+  | 'jwks_uri'
+
+export type OidcDiscoveryEndpointName = Exclude<OidcEndpointName, 'discovery'>
+export type OidcEndpointStatus = 'pass' | 'warn' | 'fail'
+
+export interface OidcPreflightRequest {
+  issuerUrl: string
+  requiredEndpoints?: OidcEndpointName[]
+  includeOptionalEndpoints?: boolean
+  timeoutMs?: number
+}
+
+export interface OidcEndpointPreflightResult {
+  endpoint: OidcEndpointName
+  label: string
+  method: 'GET' | 'HEAD' | 'POST'
+  status: OidcEndpointStatus
+  url?: string
+  httpStatus?: number
+  httpStatusText?: string
+  message: string
+  error?: string
+}
+
+export interface OidcPreflightReport {
+  issuerUrl: string
+  normalizedIssuerUrl: string
+  discoveryUrl: string
+  generatedAt: string
+  summary: {
+    pass: number
+    warn: number
+    fail: number
+  }
+  config?: OidcConfiguration
+  endpoints: OidcEndpointPreflightResult[]
+}
+
+export interface OidcDiscoveredEndpoints {
+  authorizationEndpoint?: string
+  tokenEndpoint?: string
+  userInfoEndpoint?: string
+  introspectionEndpoint?: string
+  jwksEndpoint?: string
+}
+
+interface OidcDiscoveryFetchResult {
+  normalizedIssuerUrl: string
+  discoveryUrl: string
+  config: OidcConfiguration
+  status: number
+  statusText: string
+}
+
+const DEFAULT_REQUIRED_ENDPOINTS: OidcEndpointName[] = [
+  'authorization_endpoint',
+  'token_endpoint',
+  'jwks_uri',
+]
+
+const DEFAULT_OPTIONAL_ENDPOINTS: OidcDiscoveryEndpointName[] = [
+  'userinfo_endpoint',
+  'introspection_endpoint',
+]
+
+const ENDPOINT_LABELS: Record<OidcEndpointName, string> = {
+  discovery: 'Discovery document',
+  authorization_endpoint: 'Authorization endpoint',
+  token_endpoint: 'Token endpoint',
+  userinfo_endpoint: 'UserInfo endpoint',
+  introspection_endpoint: 'Introspection endpoint',
+  jwks_uri: 'JWKS endpoint',
+}
+
+const ENDPOINT_METHODS: Record<OidcDiscoveryEndpointName, 'GET' | 'HEAD' | 'POST'> = {
+  authorization_endpoint: 'HEAD',
+  token_endpoint: 'POST',
+  userinfo_endpoint: 'GET',
+  introspection_endpoint: 'POST',
+  jwks_uri: 'GET',
+}
+
+export function normalizeIssuerUrl(rawIssuerUrl: string): string {
+  const trimmed = rawIssuerUrl.trim()
+  if (!trimmed) {
+    throw new Error('Issuer URL is required')
+  }
+
+  const withScheme = /^[a-zA-Z][a-zA-Z\d+.-]*:\/\//.test(trimmed) ? trimmed : `https://${trimmed}`
+
+  const parsed = new URL(withScheme)
+  parsed.search = ''
+  parsed.hash = ''
+
+  const normalizedPath = parsed.pathname.replace(/\/+$/, '')
+  return `${parsed.protocol}//${parsed.host}${normalizedPath}`
+}
+
+export function buildOidcDiscoveryUrl(issuerUrl: string): string {
+  const normalizedIssuerUrl = normalizeIssuerUrl(issuerUrl)
+  const issuer = new URL(normalizedIssuerUrl)
+  const basePath = issuer.pathname.endsWith('/') ? issuer.pathname : `${issuer.pathname}/`
+  return new URL(`${basePath}.well-known/openid-configuration`, issuer.origin).toString()
+}
+
+export async function fetchOidcDiscoveryConfiguration(
+  issuerUrl: string
+): Promise<OidcDiscoveryFetchResult> {
+  const normalizedIssuerUrl = normalizeIssuerUrl(issuerUrl)
+  const discoveryUrl = buildOidcDiscoveryUrl(normalizedIssuerUrl)
+
+  const response = await proxyFetch(discoveryUrl)
+  if (!response.ok) {
+    throw new Error(await buildResponseError(response, 'OIDC discovery failed'))
+  }
+
+  const rawBody = (await response.json()) as unknown
+  if (!rawBody || typeof rawBody !== 'object') {
+    throw new Error('OIDC discovery returned an invalid document')
+  }
+
+  return {
+    normalizedIssuerUrl,
+    discoveryUrl,
+    config: rawBody as OidcConfiguration,
+    status: response.status,
+    statusText: response.statusText,
+  }
+}
+
+export function extractDiscoveredEndpoints(
+  config: Partial<OidcConfiguration>
+): OidcDiscoveredEndpoints {
+  return {
+    authorizationEndpoint: getStringValue(config.authorization_endpoint),
+    tokenEndpoint: getStringValue(config.token_endpoint),
+    userInfoEndpoint: getStringValue(config.userinfo_endpoint),
+    introspectionEndpoint: getStringValue(config.introspection_endpoint),
+    jwksEndpoint: getStringValue(config.jwks_uri),
+  }
+}
+
+export function hasUsableDiscoveredEndpoints(config: Partial<OidcConfiguration>): boolean {
+  const endpoints = extractDiscoveredEndpoints(config)
+  return Boolean(
+    endpoints.authorizationEndpoint ||
+    endpoints.tokenEndpoint ||
+    endpoints.userInfoEndpoint ||
+    endpoints.introspectionEndpoint ||
+    endpoints.jwksEndpoint
+  )
+}
+
+export async function runOidcEndpointPreflight(
+  request: OidcPreflightRequest
+): Promise<OidcPreflightReport> {
+  const requiredEndpoints = request.requiredEndpoints?.length
+    ? request.requiredEndpoints
+    : DEFAULT_REQUIRED_ENDPOINTS
+  const includeOptionalEndpoints = request.includeOptionalEndpoints ?? true
+  const timeoutMs = request.timeoutMs ?? 8000
+
+  const normalizedIssuerUrl = normalizeIssuerUrl(request.issuerUrl)
+  const discoveryUrl = buildOidcDiscoveryUrl(normalizedIssuerUrl)
+  const endpoints: OidcEndpointPreflightResult[] = []
+
+  let discoveryResult: OidcDiscoveryFetchResult
+  try {
+    discoveryResult = await fetchOidcDiscoveryConfiguration(normalizedIssuerUrl)
+    endpoints.push({
+      endpoint: 'discovery',
+      label: ENDPOINT_LABELS.discovery,
+      method: 'GET',
+      status: classifyStatus('discovery', discoveryResult.status),
+      url: discoveryResult.discoveryUrl,
+      httpStatus: discoveryResult.status,
+      httpStatusText: discoveryResult.statusText,
+      message: `Fetched discovery document (${discoveryResult.status})`,
+    })
+  } catch (error) {
+    endpoints.push({
+      endpoint: 'discovery',
+      label: ENDPOINT_LABELS.discovery,
+      method: 'GET',
+      status: 'fail',
+      url: discoveryUrl,
+      message: 'Unable to fetch discovery document',
+      error: error instanceof Error ? error.message : String(error),
+    })
+
+    return {
+      issuerUrl: request.issuerUrl,
+      normalizedIssuerUrl,
+      discoveryUrl,
+      generatedAt: new Date().toISOString(),
+      summary: summarizeResults(endpoints),
+      endpoints,
+    }
+  }
+
+  const keysToCheck = resolveEndpointsToProbe(requiredEndpoints, includeOptionalEndpoints)
+
+  const requiredSet = new Set(requiredEndpoints)
+
+  for (const key of keysToCheck) {
+    const endpointUrl = getStringValue(discoveryResult.config[key])
+    if (!endpointUrl) {
+      endpoints.push({
+        endpoint: key,
+        label: ENDPOINT_LABELS[key],
+        method: ENDPOINT_METHODS[key],
+        status: requiredSet.has(key) ? 'fail' : 'warn',
+        message: requiredSet.has(key)
+          ? `${ENDPOINT_LABELS[key]} is missing from discovery document`
+          : `${ENDPOINT_LABELS[key]} is not published by this provider`,
+      })
+      continue
+    }
+
+    if (!isValidAbsoluteUrl(endpointUrl)) {
+      endpoints.push({
+        endpoint: key,
+        label: ENDPOINT_LABELS[key],
+        method: ENDPOINT_METHODS[key],
+        status: requiredSet.has(key) ? 'fail' : 'warn',
+        url: endpointUrl,
+        message: `${ENDPOINT_LABELS[key]} is not a valid absolute URL`,
+      })
+      continue
+    }
+
+    const probeResult = await probeEndpoint({
+      endpoint: key,
+      url: endpointUrl,
+      method: ENDPOINT_METHODS[key],
+      timeoutMs,
+    })
+
+    endpoints.push(probeResult)
+  }
+
+  return {
+    issuerUrl: request.issuerUrl,
+    normalizedIssuerUrl,
+    discoveryUrl,
+    generatedAt: new Date().toISOString(),
+    summary: summarizeResults(endpoints),
+    config: discoveryResult.config,
+    endpoints,
+  }
+}
+
+function getStringValue(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+function isValidAbsoluteUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+function summarizeResults(results: OidcEndpointPreflightResult[]) {
+  return results.reduce(
+    (summary, result) => {
+      summary[result.status] += 1
+      return summary
+    },
+    { pass: 0, warn: 0, fail: 0 }
+  )
+}
+
+async function buildResponseError(response: Response, prefix: string): Promise<string> {
+  let details = ''
+  try {
+    const body = await response.clone().json()
+    if (body && typeof body === 'object') {
+      details = ` - ${JSON.stringify(body)}`
+    }
+  } catch {
+    try {
+      const text = await response.clone().text()
+      if (text) {
+        details = ` - ${text.slice(0, 160)}`
+      }
+    } catch {
+      details = ''
+    }
+  }
+
+  return `${prefix}: ${response.status} ${response.statusText}${details}`
+}
+
+async function probeEndpoint(input: {
+  endpoint: OidcDiscoveryEndpointName
+  url: string
+  method: 'GET' | 'HEAD' | 'POST'
+  timeoutMs: number
+}): Promise<OidcEndpointPreflightResult> {
+  const controller = new AbortController()
+  const timeoutHandle = setTimeout(() => controller.abort(), input.timeoutMs)
+
+  try {
+    const requestInit = createProbeRequest(input.endpoint, input.method, controller.signal)
+    const response = await proxyFetch(input.url, requestInit)
+
+    return {
+      endpoint: input.endpoint,
+      label: ENDPOINT_LABELS[input.endpoint],
+      method: input.method,
+      status: classifyStatus(input.endpoint, response.status),
+      url: input.url,
+      httpStatus: response.status,
+      httpStatusText: response.statusText,
+      message: describeProbeResult(input.endpoint, response.status),
+    }
+  } catch (error) {
+    return {
+      endpoint: input.endpoint,
+      label: ENDPOINT_LABELS[input.endpoint],
+      method: input.method,
+      status: classifyProbeError(error),
+      url: input.url,
+      message:
+        classifyProbeError(error) === 'warn'
+          ? 'Network/CORS prevented browser probe'
+          : 'Probe failed',
+      error: error instanceof Error ? error.message : String(error),
+    }
+  } finally {
+    clearTimeout(timeoutHandle)
+  }
+}
+
+function createProbeRequest(
+  endpoint: OidcDiscoveryEndpointName,
+  method: 'GET' | 'HEAD' | 'POST',
+  signal: AbortSignal
+): RequestInit {
+  const headers: Record<string, string> = {
+    Accept: 'application/json, text/plain, */*',
+  }
+
+  let body: string | undefined
+  if (method === 'POST') {
+    headers['Content-Type'] = 'application/x-www-form-urlencoded'
+    if (endpoint === 'token_endpoint') {
+      body = 'grant_type=client_credentials&client_id=oidc_preflight'
+    } else if (endpoint === 'introspection_endpoint') {
+      body = 'token=oidc_preflight'
+    }
+  }
+
+  if (endpoint === 'userinfo_endpoint') {
+    headers.Authorization = 'Bearer oidc-preflight-token'
+  }
+
+  return {
+    method,
+    headers,
+    body,
+    redirect: 'manual',
+    signal,
+  }
+}
+
+function resolveEndpointsToProbe(
+  requiredEndpoints: OidcEndpointName[],
+  includeOptionalEndpoints: boolean
+): OidcDiscoveryEndpointName[] {
+  const requiredDiscoveryEndpoints = requiredEndpoints.filter(
+    (endpoint): endpoint is OidcDiscoveryEndpointName => endpoint !== 'discovery'
+  )
+  const discovered = new Set<OidcDiscoveryEndpointName>(requiredDiscoveryEndpoints)
+
+  if (includeOptionalEndpoints) {
+    for (const endpoint of DEFAULT_OPTIONAL_ENDPOINTS) {
+      discovered.add(endpoint)
+    }
+  }
+
+  for (const endpoint of ['authorization_endpoint', 'token_endpoint', 'jwks_uri'] as const) {
+    discovered.add(endpoint)
+  }
+
+  return Array.from(discovered)
+}
+
+function classifyStatus(endpoint: OidcEndpointName, statusCode: number): OidcEndpointStatus {
+  if (statusCode >= 200 && statusCode < 300) return 'pass'
+
+  if (statusCode >= 300 && statusCode < 400) {
+    return endpoint === 'authorization_endpoint' || endpoint === 'discovery' ? 'pass' : 'warn'
+  }
+
+  if ([400, 401, 403].includes(statusCode)) {
+    return endpoint === 'discovery' ? 'warn' : 'pass'
+  }
+
+  if (statusCode === 405) return 'warn'
+  if (statusCode >= 500) return 'fail'
+  if (statusCode === 404 || statusCode === 410) return 'fail'
+
+  return 'warn'
+}
+
+function describeProbeResult(endpoint: OidcEndpointName, statusCode: number): string {
+  if (statusCode >= 200 && statusCode < 300) {
+    return `${ENDPOINT_LABELS[endpoint]} is reachable`
+  }
+
+  if (statusCode >= 300 && statusCode < 400) {
+    return `${ENDPOINT_LABELS[endpoint]} redirected (${statusCode})`
+  }
+
+  if ([400, 401, 403].includes(statusCode)) {
+    return `${ENDPOINT_LABELS[endpoint]} is reachable and enforcing input/auth checks`
+  }
+
+  if (statusCode === 405) {
+    return `${ENDPOINT_LABELS[endpoint]} rejected probe method but appears reachable`
+  }
+
+  if (statusCode >= 500) {
+    return `${ENDPOINT_LABELS[endpoint]} returned a server error`
+  }
+
+  return `${ENDPOINT_LABELS[endpoint]} returned status ${statusCode}`
+}
+
+function classifyProbeError(error: unknown): OidcEndpointStatus {
+  if (error instanceof DOMException && error.name === 'AbortError') {
+    return 'warn'
+  }
+
+  if (error instanceof Error && error.message.toLowerCase().includes('failed to fetch')) {
+    return 'warn'
+  }
+
+  return 'fail'
+}

--- a/src/features/oidcExplorer/components/JwksDisplay.tsx
+++ b/src/features/oidcExplorer/components/JwksDisplay.tsx
@@ -73,62 +73,73 @@ export function JwksDisplay({ jwks, jwksUri }: JwksDisplayProps) {
     // Skip the kid and kty as they're shown elsewhere
     if (key === 'kid' || key === 'kty') return null
 
-    let displayValue = ''
-    let description = ''
-
-    switch (key) {
-      case 'use':
-        displayValue = value === 'sig' ? 'Signature' : value === 'enc' ? 'Encryption' : value
-        description = 'Intended use for the key'
-        break
-      case 'alg':
-        displayValue = value
-        description = getAlgorithmDescription(value)
-        break
-      case 'n':
-        displayValue = `${value.substring(0, 20)}...`
-        description = 'RSA modulus (base64url encoded)'
-        break
-      case 'e':
-        displayValue = value
-        description = 'RSA exponent (base64url encoded)'
-        break
-      case 'x5c':
-        displayValue = `${Array.isArray(value) ? value.length : 0} certificate(s)`
-        description = 'X.509 certificate chain'
-        break
-      case 'x5t':
-        displayValue = formatFingerprint(value)
-        description = 'X.509 certificate SHA-1 thumbprint'
-        break
-      case 'x5t#S256':
-        displayValue = formatFingerprint(value)
-        description = 'X.509 certificate SHA-256 thumbprint'
-        break
-      case 'crv':
-        displayValue = value
-        description = 'Curve for EC keys'
-        break
-      case 'x':
-        displayValue = `${value.substring(0, 20)}...`
-        description = 'X coordinate for EC key'
-        break
-      case 'y':
-        displayValue = `${value.substring(0, 20)}...`
-        description = 'Y coordinate for EC key'
-        break
-      default:
-        displayValue = typeof value === 'object' ? JSON.stringify(value) : String(value)
-        description = 'Additional key parameter'
-    }
+    const details = (() => {
+      switch (key) {
+        case 'use':
+          return {
+            displayValue: value === 'sig' ? 'Signature' : value === 'enc' ? 'Encryption' : value,
+            description: 'Intended use for the key',
+          }
+        case 'alg':
+          return {
+            displayValue: value,
+            description: getAlgorithmDescription(value),
+          }
+        case 'n':
+          return {
+            displayValue: `${value.substring(0, 20)}...`,
+            description: 'RSA modulus (base64url encoded)',
+          }
+        case 'e':
+          return {
+            displayValue: value,
+            description: 'RSA exponent (base64url encoded)',
+          }
+        case 'x5c':
+          return {
+            displayValue: `${Array.isArray(value) ? value.length : 0} certificate(s)`,
+            description: 'X.509 certificate chain',
+          }
+        case 'x5t':
+          return {
+            displayValue: formatFingerprint(value),
+            description: 'X.509 certificate SHA-1 thumbprint',
+          }
+        case 'x5t#S256':
+          return {
+            displayValue: formatFingerprint(value),
+            description: 'X.509 certificate SHA-256 thumbprint',
+          }
+        case 'crv':
+          return {
+            displayValue: value,
+            description: 'Curve for EC keys',
+          }
+        case 'x':
+          return {
+            displayValue: `${value.substring(0, 20)}...`,
+            description: 'X coordinate for EC key',
+          }
+        case 'y':
+          return {
+            displayValue: `${value.substring(0, 20)}...`,
+            description: 'Y coordinate for EC key',
+          }
+        default:
+          return {
+            displayValue: typeof value === 'object' ? JSON.stringify(value) : String(value),
+            description: 'Additional key parameter',
+          }
+      }
+    })()
 
     return (
       <tr key={key}>
         <td className="w-1/4 font-medium">{key}</td>
         <td className="w-2/5 break-all">
-          <code>{displayValue}</code>
+          <code>{details.displayValue}</code>
         </td>
-        <td className="w-2/5">{description}</td>
+        <td className="w-2/5">{details.description}</td>
       </tr>
     )
   }

--- a/src/features/oidcExplorer/utils/config-helpers.ts
+++ b/src/features/oidcExplorer/utils/config-helpers.ts
@@ -76,7 +76,8 @@ export async function fetchJwks(jwksUri: string): Promise<Jwks> {
     // Enhance error messages for common issues
     if (error.message.includes('NetworkError') || error.message.includes('Failed to fetch')) {
       throw new Error(
-        `CORS error: Could not fetch JWKS from ${jwksUri}. The server may not allow direct browser access.`
+        `CORS error: Could not fetch JWKS from ${jwksUri}. The server may not allow direct browser access.`,
+        { cause: error }
       )
     }
 

--- a/src/hooks/data-fetching/useOidcConfig.ts
+++ b/src/hooks/data-fetching/useOidcConfig.ts
@@ -10,81 +10,86 @@ import {
  * Hook to fetch OIDC configuration from an issuer URL.
  * Handles fetching via proxy if necessary.
  */
-export function useOidcConfig(): UseOidcConfigResult {
+export function useOidcConfig(options: UseOidcConfigOptions = {}): UseOidcConfigResult {
   const [data, setData] = useState<OidcConfiguration | null>(null)
   const [currentIssuer, setCurrentIssuer] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [error, setError] = useState<Error | null>(null)
   const requestIdRef = useRef(0)
+  const fetchDiscoveryConfiguration =
+    options.fetchDiscoveryConfiguration ?? fetchOidcDiscoveryConfiguration
 
-  const fetchConfig = useCallback(async (issuerUrl: string) => {
-    if (!issuerUrl || issuerUrl.trim().length === 0) {
-      setCurrentIssuer(null)
-      setData(null)
-      setError(null)
-      setIsLoading(false)
-      return
-    }
-
-    let normalizedIssuerUrl: string
-    try {
-      normalizedIssuerUrl = normalizeIssuerUrl(issuerUrl)
-    } catch (error) {
-      setError(
-        new Error('Invalid Issuer URL format.', {
-          cause: error instanceof Error ? error : undefined,
-        })
-      )
-      setData(null)
-      setIsLoading(false)
-      return
-    }
-
-    setCurrentIssuer(normalizedIssuerUrl)
-
-    // Check cache first
-    const cachedConfig = oidcConfigCache.get(normalizedIssuerUrl)
-    if (cachedConfig) {
-      if (import.meta?.env?.DEV) {
-        console.log('Using cached OIDC configuration for:', normalizedIssuerUrl)
-      }
-      setData(cachedConfig)
-      setError(null)
-      setIsLoading(false)
-      return
-    }
-
-    setIsLoading(true)
-    setError(null)
-    setData(null)
-
-    const requestId = ++requestIdRef.current
-
-    try {
-      const { config } = await fetchOidcDiscoveryConfiguration(normalizedIssuerUrl)
-      const configData = config as OidcConfiguration
-
-      // Store in cache for future use
-      oidcConfigCache.set(normalizedIssuerUrl, configData)
-      if (import.meta?.env?.DEV) {
-        console.log('Cached OIDC configuration for:', normalizedIssuerUrl)
-      }
-
-      if (requestIdRef.current === requestId) {
-        setData(configData)
-      }
-    } catch (err) {
-      if (import.meta?.env?.DEV) {
-        console.error('Error fetching OIDC config:', err)
-      }
-      setError(err instanceof Error ? err : new Error('An unknown error occurred'))
-      setData(null)
-    } finally {
-      if (requestIdRef.current === requestId) {
+  const fetchConfig = useCallback(
+    async (issuerUrl: string) => {
+      if (!issuerUrl || issuerUrl.trim().length === 0) {
+        setCurrentIssuer(null)
+        setData(null)
+        setError(null)
         setIsLoading(false)
+        return
       }
-    }
-  }, [])
+
+      let normalizedIssuerUrl: string
+      try {
+        normalizedIssuerUrl = normalizeIssuerUrl(issuerUrl)
+      } catch (error) {
+        setError(
+          new Error('Invalid Issuer URL format.', {
+            cause: error instanceof Error ? error : undefined,
+          })
+        )
+        setData(null)
+        setIsLoading(false)
+        return
+      }
+
+      setCurrentIssuer(normalizedIssuerUrl)
+
+      // Check cache first
+      const cachedConfig = oidcConfigCache.get(normalizedIssuerUrl)
+      if (cachedConfig) {
+        if (import.meta?.env?.DEV) {
+          console.log('Using cached OIDC configuration for:', normalizedIssuerUrl)
+        }
+        setData(cachedConfig)
+        setError(null)
+        setIsLoading(false)
+        return
+      }
+
+      setIsLoading(true)
+      setError(null)
+      setData(null)
+
+      const requestId = ++requestIdRef.current
+
+      try {
+        const { config } = await fetchDiscoveryConfiguration(normalizedIssuerUrl)
+        const configData = config as OidcConfiguration
+
+        // Store in cache for future use
+        oidcConfigCache.set(normalizedIssuerUrl, configData)
+        if (import.meta?.env?.DEV) {
+          console.log('Cached OIDC configuration for:', normalizedIssuerUrl)
+        }
+
+        if (requestIdRef.current === requestId) {
+          setData(configData)
+        }
+      } catch (err) {
+        if (import.meta?.env?.DEV) {
+          console.error('Error fetching OIDC config:', err)
+        }
+        setError(err instanceof Error ? err : new Error('An unknown error occurred'))
+        setData(null)
+      } finally {
+        if (requestIdRef.current === requestId) {
+          setIsLoading(false)
+        }
+      }
+    },
+    [fetchDiscoveryConfiguration]
+  )
 
   // We don't fetch automatically on mount, but provide a function to trigger fetching
   return { data, currentIssuer, isLoading, error, fetchConfig }
@@ -96,4 +101,8 @@ interface UseOidcConfigResult {
   isLoading: boolean
   error: Error | null
   fetchConfig: (url: string) => Promise<void>
+}
+
+interface UseOidcConfigOptions {
+  fetchDiscoveryConfiguration?: typeof fetchOidcDiscoveryConfiguration
 }

--- a/src/hooks/data-fetching/useOidcConfig.ts
+++ b/src/hooks/data-fetching/useOidcConfig.ts
@@ -1,7 +1,10 @@
 import { useCallback, useRef, useState } from 'react'
-import { proxyFetch } from '@/lib/proxy-fetch'
 import { oidcConfigCache } from '@/lib/cache/oidc-config-cache'
 import type { OidcConfiguration } from '@/features/oidcExplorer/utils/types' // Assuming types exist here
+import {
+  fetchOidcDiscoveryConfiguration,
+  normalizeIssuerUrl,
+} from '@/features/oauthPlayground/utils/oidc-preflight'
 
 /**
  * Hook to fetch OIDC configuration from an issuer URL.
@@ -15,7 +18,7 @@ export function useOidcConfig(): UseOidcConfigResult {
   const requestIdRef = useRef(0)
 
   const fetchConfig = useCallback(async (issuerUrl: string) => {
-    if (!issuerUrl) {
+    if (!issuerUrl || issuerUrl.trim().length === 0) {
       setCurrentIssuer(null)
       setData(null)
       setError(null)
@@ -23,27 +26,27 @@ export function useOidcConfig(): UseOidcConfigResult {
       return
     }
 
-    setCurrentIssuer(issuerUrl)
-
-    // Construct the well-known URL
-    let wellKnownUrl = ''
+    let normalizedIssuerUrl: string
     try {
-      const url = new URL(issuerUrl)
-      // Ensure trailing slash for correct joining
-      const basePath = url.pathname.endsWith('/') ? url.pathname : `${url.pathname}/`
-      wellKnownUrl = new URL(`${basePath}.well-known/openid-configuration`, url.origin).toString()
-    } catch {
-      setError(new Error('Invalid Issuer URL format.'))
+      normalizedIssuerUrl = normalizeIssuerUrl(issuerUrl)
+    } catch (error) {
+      setError(
+        new Error('Invalid Issuer URL format.', {
+          cause: error instanceof Error ? error : undefined,
+        })
+      )
       setData(null)
       setIsLoading(false)
       return
     }
 
+    setCurrentIssuer(normalizedIssuerUrl)
+
     // Check cache first
-    const cachedConfig = oidcConfigCache.get(issuerUrl)
+    const cachedConfig = oidcConfigCache.get(normalizedIssuerUrl)
     if (cachedConfig) {
       if (import.meta?.env?.DEV) {
-        console.log('Using cached OIDC configuration for:', issuerUrl)
+        console.log('Using cached OIDC configuration for:', normalizedIssuerUrl)
       }
       setData(cachedConfig)
       setError(null)
@@ -58,25 +61,13 @@ export function useOidcConfig(): UseOidcConfigResult {
     const requestId = ++requestIdRef.current
 
     try {
-      const response = await proxyFetch(wellKnownUrl)
-
-      if (!response.ok) {
-        let errorMsg = `Failed to fetch OIDC configuration: ${response.status} ${response.statusText}`
-        try {
-          const errorBody = await response.json()
-          errorMsg += ` - ${JSON.stringify(errorBody)}`
-        } catch {
-          /* Ignore if response body is not JSON */
-        }
-        throw new Error(errorMsg)
-      }
-
-      const configData: OidcConfiguration = await response.json()
+      const { config } = await fetchOidcDiscoveryConfiguration(normalizedIssuerUrl)
+      const configData = config as OidcConfiguration
 
       // Store in cache for future use
-      oidcConfigCache.set(issuerUrl, configData)
+      oidcConfigCache.set(normalizedIssuerUrl, configData)
       if (import.meta?.env?.DEV) {
-        console.log('Cached OIDC configuration for:', issuerUrl)
+        console.log('Cached OIDC configuration for:', normalizedIssuerUrl)
       }
 
       if (requestIdRef.current === requestId) {

--- a/src/lib/jwt/generate-signed-token.ts
+++ b/src/lib/jwt/generate-signed-token.ts
@@ -1,96 +1,44 @@
-import { DEMO_JWKS } from './demo-key'
+import { signToken } from './sign-token'
 
 /**
- * Determines the host URL for the current environment
- * @returns The base URL for the current environment
+ * Determines the host URL for the current environment.
  */
 export function getIssuerBaseUrl(): string {
   const host = window.location.host
   const protocol = window.location.protocol
 
-  // For local development with Cloudflare workers
   if (host.includes('localhost') && host.includes('5173')) {
-    // Use the local wrangler development server for the API
     return 'http://localhost:8788/api'
   }
 
-  // For production (or any other environment)
   return `${protocol}//${host}/api`
 }
 
 /**
- * Creates a simulated JWT token with a dummy signature
- * This is a fallback method that doesn't rely on WebCrypto API
- *
- * @param payload Optional custom payload to include in the token
- * @returns A JWT string
+ * Creates a signed demo JWT token using the shared signing utility.
  */
-export async function generateSignedToken(payload?: Record<string, any>): Promise<string> {
+export async function generateSignedToken(payload?: Record<string, unknown>): Promise<string> {
   const currentTime = Math.floor(Date.now() / 1000)
   const issuer = getIssuerBaseUrl()
 
-  if (import.meta?.env?.DEV) {
-    console.log('Generating token with issuer:', issuer)
-  }
-
-  // Create the default payload
   const defaultPayload = {
-    // Standard claims
     sub: '1234567890',
     name: 'John Doe',
     email: 'john.doe@example.com',
     iat: currentTime,
-    exp: currentTime + 3600, // 1 hour from now
+    exp: currentTime + 3600,
     aud: 'example-client',
     iss: issuer,
-
-    // Some additional claims for demo purposes
     preferred_username: 'johndoe',
     groups: ['users', 'premium'],
     scope: 'openid profile email api:read',
-
-    // Add a marker to identify this as a demo token
     is_demo_token: true,
-
-    // Allow custom overrides
     ...payload,
   }
 
-  try {
-    // Create the header
-    const header = {
-      alg: 'RS256',
-      typ: 'JWT',
-      kid: DEMO_JWKS.keys[0].kid, // Use the kid from the JWKS
-    }
-
-    // Encode header and payload
-    const encodedHeader = base64UrlEncode(JSON.stringify(header))
-    const encodedPayload = base64UrlEncode(JSON.stringify(defaultPayload))
-
-    // For the demo token, we'll use a dummy signature that looks realistic
-    // In real applications, this would be an actual signature created with the private key
-    const dummySignature =
-      'XCopO5RSxCARj0BoTPaHQXPFMjQ4inuX1TnuNKRdCrQyJsX0olYtR3NKkWQRgGmFu9xOEcrt1YOOQeLgoAPUOcLTpLPcMZrSUxTxnUMJ2tHQH8X2Em1MoVCLWpt2YzQF9-XJQ5NIHs_NqZECYlECNJ5S9QDm1QGY2K4FApukuUWuZz68I9qJQTjXLCfUMEKpz7TzT9vLsJ8J_rvLXa2_TFgyBWVKMKjWl5dn2-EA9TuHzZYMDmHPdMbcuFXNxcMX4vcLrK6YUyLdZ8mWHKFwQQgyo6jnV8363CByn-jHbFYBxYYKavZ2qNmn-fvTkbFx3rHFh-OVLThBngWGhQ'
-
-    // Return the token
-    return `${encodedHeader}.${encodedPayload}.${dummySignature}`
-  } catch (error) {
-    if (import.meta?.env?.DEV) {
-      console.error('Error generating token:', error)
-    }
-    throw error
+  if (import.meta?.env?.DEV) {
+    console.log('Generating demo signed token')
   }
-}
 
-/**
- * Encode a string as base64url
- * @param str The string to encode
- * @returns base64url encoded string
- */
-function base64UrlEncode(str: string): string {
-  // First convert the string to base64
-  const base64 = btoa(str)
-  // Then convert base64 to base64url by replacing characters
-  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+  return await signToken(defaultPayload)
 }

--- a/src/lib/jwt/sign-token.ts
+++ b/src/lib/jwt/sign-token.ts
@@ -1,83 +1,67 @@
-// src/lib/jwt/sign-token.ts
 import { SignJWT } from 'jose'
-import { DEMO_PRIVATE_KEY } from './demo-key' // Uses your new key
+import { DEMO_PRIVATE_KEY } from './demo-key'
 
 /**
  * Signs a JWT token with the demo private key.
- * Now simplified after debugging.
- *
- * @param payload The payload to include in the token
- * @param header Optional additional header parameters
- * @returns A properly signed JWT string
  */
 export async function signToken(
-  payload: Record<string, any>,
-  header: Record<string, any> = {}
+  payload: Record<string, unknown>,
+  header: Record<string, unknown> = {}
 ): Promise<string> {
   let privateKey: CryptoKey
+
   try {
-    // 1. Import the private key
-    if (import.meta?.env?.DEV) console.log('[signToken] Importing private key...')
     privateKey = await importPrivateKey(DEMO_PRIVATE_KEY)
-    if (import.meta?.env?.DEV) console.log('[signToken] Private key imported successfully.')
-  } catch (importError: any) {
-    console.error('[signToken] Error importing private key:', importError)
-    throw new Error(`Failed to import private key: ${importError.message || importError}`)
+  } catch (error) {
+    if (import.meta?.env?.DEV) {
+      console.error('[signToken] Failed to import private key:', error)
+    }
+
+    throw new Error('Failed to import private key', { cause: error })
   }
 
   try {
-    // 2. Prepare the JWT with headers using jose
-    if (import.meta?.env?.DEV) console.log('[signToken] Preparing JWT for signing with jose...')
     let jwt = new SignJWT(payload).setProtectedHeader({
-      alg: 'RS256', // Algorithm defined in your key
+      alg: 'RS256',
       typ: 'JWT',
-      kid: DEMO_PRIVATE_KEY.kid, // *** Use the Key ID from your key file ***
+      kid: DEMO_PRIVATE_KEY.kid,
       ...header,
     })
 
-    // Add standard timestamps if not provided in payload
-    if (!payload.iat) jwt = jwt.setIssuedAt()
-    if (!payload.exp) jwt = jwt.setExpirationTime('1h') // Default 1 hour expiry
+    if (payload.iat == null) {
+      jwt = jwt.setIssuedAt()
+    }
 
-    // 3. Sign the JWT using jose and the imported key
-    if (import.meta?.env?.DEV) console.log('[signToken] Attempting to sign JWT with jose...')
-    const signedToken = await jwt.sign(privateKey)
-    if (import.meta?.env?.DEV) console.log('[signToken] JWT signed successfully with jose.')
-    return signedToken
-  } catch (joseSignError: any) {
-    console.error('[signToken] Error during jose JWT signing:', joseSignError)
-    if (joseSignError.message)
-      console.error('[signToken] Jose Sign Error Message:', joseSignError.message)
-    // Re-throw for higher-level components to catch
-    throw joseSignError
+    if (payload.exp == null) {
+      jwt = jwt.setExpirationTime('1h')
+    }
+
+    return await jwt.sign(privateKey)
+  } catch (error) {
+    if (import.meta?.env?.DEV) {
+      console.error('[signToken] Failed to sign JWT:', error)
+    }
+
+    throw new Error('Failed to sign JWT token', { cause: error })
   }
 }
 
 /**
  * Imports a JWK as a CryptoKey for signing using Web Crypto API.
  */
-async function importPrivateKey(jwk: any): Promise<CryptoKey> {
-  try {
-    // Check if necessary APIs exist
-    if (!crypto?.subtle?.importKey) {
-      throw new Error('crypto.subtle.importKey is not available.')
-    }
-
-    // Import the key using corrected parameters
-    const key = await crypto.subtle.importKey(
-      'jwk',
-      jwk,
-      {
-        name: 'RSASSA-PKCS1-v1_5', // Algorithm name
-        hash: { name: 'SHA-256' }, // Hash function for the algorithm
-      },
-      false, // Exportable flag (false for private keys usually)
-      ['sign'] // Key usage - we want to sign with it
-    )
-    console.log('[importPrivateKey] crypto.subtle.importKey succeeded.')
-    return key
-  } catch (error: any) {
-    console.error('[importPrivateKey] Error during crypto.subtle.importKey:', error)
-    throw error // Re-throw to be caught by signToken
+async function importPrivateKey(jwk: JsonWebKey): Promise<CryptoKey> {
+  if (!crypto?.subtle?.importKey) {
+    throw new Error('crypto.subtle.importKey is not available')
   }
+
+  return await crypto.subtle.importKey(
+    'jwk',
+    jwk,
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      hash: { name: 'SHA-256' },
+    },
+    false,
+    ['sign']
+  )
 }

--- a/src/lib/jwt/verify-signature-with-refresh.ts
+++ b/src/lib/jwt/verify-signature-with-refresh.ts
@@ -23,7 +23,7 @@ export async function verifySignatureWithRefresh(
 ): Promise<VerifyResult> {
   try {
     if (import.meta?.env?.DEV) {
-      console.log('Starting signature verification with token:', token.substring(0, 20) + '...')
+      console.log('Starting signature verification')
     }
 
     if (!initialJwks?.keys?.length) {
@@ -36,7 +36,12 @@ export async function verifySignatureWithRefresh(
     // Extract the JWK that matches the token's kid (key ID)
     const tokenHeader = JSON.parse(atob(token.split('.')[0].replace(/-/g, '+').replace(/_/g, '/')))
 
-    if (import.meta?.env?.DEV) console.log('Token header:', tokenHeader)
+    if (import.meta?.env?.DEV) {
+      console.log('Token header parsed', {
+        kid: tokenHeader?.kid,
+        alg: tokenHeader?.alg,
+      })
+    }
 
     // Check if the token has a key ID
     if (!tokenHeader.kid) {
@@ -58,7 +63,9 @@ export async function verifySignatureWithRefresh(
       }
 
       try {
-        if (import.meta?.env?.DEV) console.log('Found matching key:', matchingKey)
+        if (import.meta?.env?.DEV) {
+          console.log('Found matching key for token header', { kid: matchingKey?.kid })
+        }
         await jwtVerify(token, await importKey(matchingKey, tokenHeader.alg))
         if (import.meta?.env?.DEV) console.log('Verification successful')
         return { valid: true }

--- a/src/tests/features/oidc-preflight.test.ts
+++ b/src/tests/features/oidc-preflight.test.ts
@@ -25,6 +25,10 @@ function resolveTargetUrl(input: Request | string): string {
   return decodeURIComponent(encodedTarget)
 }
 
+function isDiscoveryUrl(target: string): boolean {
+  return target.includes('/.well-known/openid-configuration')
+}
+
 describe('OIDC endpoint preflight', () => {
   beforeEach(() => {
     globalThis.fetch = mock(async () => createJsonResponse({ error: 'not mocked' }, 404)) as any
@@ -37,7 +41,7 @@ describe('OIDC endpoint preflight', () => {
   test('fetches discovery document and normalizes issuer URL', async () => {
     ;(globalThis.fetch as any).mockImplementation(async (input: Request | string) => {
       const target = resolveTargetUrl(input)
-      if (target === 'https://issuer.example.com/tenant/.well-known/openid-configuration') {
+      if (target.endsWith('/tenant/.well-known/openid-configuration')) {
         return createJsonResponse({
           issuer: 'https://issuer.example.com/tenant',
           authorization_endpoint: 'https://issuer.example.com/tenant/oauth2/authorize',
@@ -61,7 +65,7 @@ describe('OIDC endpoint preflight', () => {
   test('fails discovery when discovery endpoint is not successful', async () => {
     ;(globalThis.fetch as any).mockImplementation(async (input: Request | string) => {
       const target = resolveTargetUrl(input)
-      if (target.endsWith('/.well-known/openid-configuration')) {
+      if (isDiscoveryUrl(target)) {
         return createJsonResponse({ error: 'unavailable' }, 503)
       }
 
@@ -77,7 +81,7 @@ describe('OIDC endpoint preflight', () => {
     ;(globalThis.fetch as any).mockImplementation(async (input: Request | string) => {
       const target = resolveTargetUrl(input)
 
-      if (target === 'https://issuer.example.com/.well-known/openid-configuration') {
+      if (isDiscoveryUrl(target)) {
         return createJsonResponse({
           issuer: 'https://issuer.example.com',
           authorization_endpoint: 'https://issuer.example.com/oauth2/authorize',
@@ -88,19 +92,19 @@ describe('OIDC endpoint preflight', () => {
         })
       }
 
-      if (target === 'https://issuer.example.com/oauth2/authorize') {
+      if (target.includes('/oauth2/authorize')) {
         return new Response(null, { status: 302, headers: { Location: '/login' } })
       }
-      if (target === 'https://issuer.example.com/oauth2/token') {
+      if (target.includes('/oauth2/token')) {
         return createJsonResponse({ error: 'invalid_client' }, 401)
       }
-      if (target === 'https://issuer.example.com/oauth2/userinfo') {
+      if (target.includes('/oauth2/userinfo')) {
         return new Response(null, { status: 405 })
       }
-      if (target === 'https://issuer.example.com/oauth2/introspect') {
+      if (target.includes('/oauth2/introspect')) {
         return createJsonResponse({ error: 'server_error' }, 503)
       }
-      if (target === 'https://issuer.example.com/oauth2/jwks') {
+      if (target.includes('/oauth2/jwks')) {
         return createJsonResponse({ error: 'missing' }, 404)
       }
 
@@ -121,41 +125,30 @@ describe('OIDC endpoint preflight', () => {
   })
 
   test('marks network, CORS, and timeout probe failures as warnings', async () => {
-    ;(globalThis.fetch as any).mockImplementation(
-      async (input: Request | string, init?: RequestInit) => {
-        const target = resolveTargetUrl(input)
+    ;(globalThis.fetch as any).mockImplementation(async (input: Request | string) => {
+      const target = resolveTargetUrl(input)
 
-        if (target === 'https://issuer.example.com/.well-known/openid-configuration') {
-          return createJsonResponse({
-            issuer: 'https://issuer.example.com',
-            authorization_endpoint: 'https://issuer.example.com/oauth2/authorize',
-            token_endpoint: 'https://issuer.example.com/oauth2/token',
-            userinfo_endpoint: 'https://issuer.example.com/oauth2/userinfo',
-            introspection_endpoint: 'https://issuer.example.com/oauth2/introspect',
-            jwks_uri: 'https://issuer.example.com/oauth2/jwks',
-          })
-        }
-
-        if (target === 'https://issuer.example.com/oauth2/token') {
-          throw new Error('Failed to fetch')
-        }
-
-        if (target === 'https://issuer.example.com/oauth2/userinfo') {
-          return await new Promise<Response>((_, reject) => {
-            const abortHandler = () => reject(new DOMException('Aborted', 'AbortError'))
-            if (init?.signal) {
-              if (init.signal.aborted) {
-                abortHandler()
-                return
-              }
-              init.signal.addEventListener('abort', abortHandler, { once: true })
-            }
-          })
-        }
-
-        return createJsonResponse({}, 200)
+      if (isDiscoveryUrl(target)) {
+        return createJsonResponse({
+          issuer: 'https://issuer.example.com',
+          authorization_endpoint: 'https://issuer.example.com/oauth2/authorize',
+          token_endpoint: 'https://issuer.example.com/oauth2/token',
+          userinfo_endpoint: 'https://issuer.example.com/oauth2/userinfo',
+          introspection_endpoint: 'https://issuer.example.com/oauth2/introspect',
+          jwks_uri: 'https://issuer.example.com/oauth2/jwks',
+        })
       }
-    )
+
+      if (target.includes('/oauth2/token')) {
+        throw new Error('Failed to fetch')
+      }
+
+      if (target.includes('/oauth2/userinfo')) {
+        throw new DOMException('Aborted', 'AbortError')
+      }
+
+      return createJsonResponse({}, 200)
+    })
 
     const report = await runOidcEndpointPreflight({
       issuerUrl: 'https://issuer.example.com',

--- a/src/tests/features/oidc-preflight.test.ts
+++ b/src/tests/features/oidc-preflight.test.ts
@@ -115,7 +115,7 @@ describe('OIDC endpoint preflight', () => {
       }
 
       if (target.includes('/oauth2/token')) {
-        throw new Error('Failed to fetch')
+        throw new TypeError('NetworkError when attempting to fetch resource.')
       }
 
       if (target.includes('/oauth2/userinfo')) {

--- a/src/tests/features/oidc-preflight.test.ts
+++ b/src/tests/features/oidc-preflight.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import {
+  fetchOidcDiscoveryConfiguration,
+  runOidcEndpointPreflight,
+} from '@/features/oauthPlayground/utils/oidc-preflight'
+
+const originalFetch = globalThis.fetch
+
+function createJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function resolveTargetUrl(input: Request | string): string {
+  const url = typeof input === 'string' ? input : input.url
+  const proxyPrefix = '/api/cors-proxy/'
+  const proxyIndex = url.indexOf(proxyPrefix)
+  if (proxyIndex === -1) {
+    return url
+  }
+
+  const encodedTarget = url.slice(proxyIndex + proxyPrefix.length)
+  return decodeURIComponent(encodedTarget)
+}
+
+describe('OIDC endpoint preflight', () => {
+  beforeEach(() => {
+    globalThis.fetch = mock(async () => createJsonResponse({ error: 'not mocked' }, 404)) as any
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test('fetches discovery document and normalizes issuer URL', async () => {
+    ;(globalThis.fetch as any).mockImplementation(async (input: Request | string) => {
+      const target = resolveTargetUrl(input)
+      if (target === 'https://issuer.example.com/tenant/.well-known/openid-configuration') {
+        return createJsonResponse({
+          issuer: 'https://issuer.example.com/tenant',
+          authorization_endpoint: 'https://issuer.example.com/tenant/oauth2/authorize',
+          token_endpoint: 'https://issuer.example.com/tenant/oauth2/token',
+          jwks_uri: 'https://issuer.example.com/tenant/oauth2/jwks',
+        })
+      }
+
+      return createJsonResponse({}, 404)
+    })
+
+    const result = await fetchOidcDiscoveryConfiguration('issuer.example.com/tenant/')
+
+    expect(result.normalizedIssuerUrl).toBe('https://issuer.example.com/tenant')
+    expect(result.discoveryUrl).toBe(
+      'https://issuer.example.com/tenant/.well-known/openid-configuration'
+    )
+    expect(result.config.token_endpoint).toBe('https://issuer.example.com/tenant/oauth2/token')
+  })
+
+  test('fails discovery when discovery endpoint is not successful', async () => {
+    ;(globalThis.fetch as any).mockImplementation(async (input: Request | string) => {
+      const target = resolveTargetUrl(input)
+      if (target.endsWith('/.well-known/openid-configuration')) {
+        return createJsonResponse({ error: 'unavailable' }, 503)
+      }
+
+      return createJsonResponse({}, 404)
+    })
+
+    await expect(fetchOidcDiscoveryConfiguration('https://issuer.example.com')).rejects.toThrow(
+      /OIDC discovery failed: 503/
+    )
+  })
+
+  test('classifies endpoint probe results across status classes', async () => {
+    ;(globalThis.fetch as any).mockImplementation(async (input: Request | string) => {
+      const target = resolveTargetUrl(input)
+
+      if (target === 'https://issuer.example.com/.well-known/openid-configuration') {
+        return createJsonResponse({
+          issuer: 'https://issuer.example.com',
+          authorization_endpoint: 'https://issuer.example.com/oauth2/authorize',
+          token_endpoint: 'https://issuer.example.com/oauth2/token',
+          userinfo_endpoint: 'https://issuer.example.com/oauth2/userinfo',
+          introspection_endpoint: 'https://issuer.example.com/oauth2/introspect',
+          jwks_uri: 'https://issuer.example.com/oauth2/jwks',
+        })
+      }
+
+      if (target === 'https://issuer.example.com/oauth2/authorize') {
+        return new Response(null, { status: 302, headers: { Location: '/login' } })
+      }
+      if (target === 'https://issuer.example.com/oauth2/token') {
+        return createJsonResponse({ error: 'invalid_client' }, 401)
+      }
+      if (target === 'https://issuer.example.com/oauth2/userinfo') {
+        return new Response(null, { status: 405 })
+      }
+      if (target === 'https://issuer.example.com/oauth2/introspect') {
+        return createJsonResponse({ error: 'server_error' }, 503)
+      }
+      if (target === 'https://issuer.example.com/oauth2/jwks') {
+        return createJsonResponse({ error: 'missing' }, 404)
+      }
+
+      return createJsonResponse({}, 404)
+    })
+
+    const report = await runOidcEndpointPreflight({ issuerUrl: 'https://issuer.example.com' })
+    const statuses = Object.fromEntries(
+      report.endpoints.map((entry) => [entry.endpoint, entry.status])
+    )
+
+    expect(statuses.discovery).toBe('pass')
+    expect(statuses.authorization_endpoint).toBe('pass')
+    expect(statuses.token_endpoint).toBe('pass')
+    expect(statuses.userinfo_endpoint).toBe('warn')
+    expect(statuses.introspection_endpoint).toBe('fail')
+    expect(statuses.jwks_uri).toBe('fail')
+  })
+
+  test('marks network, CORS, and timeout probe failures as warnings', async () => {
+    ;(globalThis.fetch as any).mockImplementation(
+      async (input: Request | string, init?: RequestInit) => {
+        const target = resolveTargetUrl(input)
+
+        if (target === 'https://issuer.example.com/.well-known/openid-configuration') {
+          return createJsonResponse({
+            issuer: 'https://issuer.example.com',
+            authorization_endpoint: 'https://issuer.example.com/oauth2/authorize',
+            token_endpoint: 'https://issuer.example.com/oauth2/token',
+            userinfo_endpoint: 'https://issuer.example.com/oauth2/userinfo',
+            introspection_endpoint: 'https://issuer.example.com/oauth2/introspect',
+            jwks_uri: 'https://issuer.example.com/oauth2/jwks',
+          })
+        }
+
+        if (target === 'https://issuer.example.com/oauth2/token') {
+          throw new Error('Failed to fetch')
+        }
+
+        if (target === 'https://issuer.example.com/oauth2/userinfo') {
+          return await new Promise<Response>((_, reject) => {
+            const abortHandler = () => reject(new DOMException('Aborted', 'AbortError'))
+            if (init?.signal) {
+              if (init.signal.aborted) {
+                abortHandler()
+                return
+              }
+              init.signal.addEventListener('abort', abortHandler, { once: true })
+            }
+          })
+        }
+
+        return createJsonResponse({}, 200)
+      }
+    )
+
+    const report = await runOidcEndpointPreflight({
+      issuerUrl: 'https://issuer.example.com',
+      timeoutMs: 5,
+    })
+
+    const tokenResult = report.endpoints.find((entry) => entry.endpoint === 'token_endpoint')
+    const userInfoResult = report.endpoints.find((entry) => entry.endpoint === 'userinfo_endpoint')
+
+    expect(tokenResult?.status).toBe('warn')
+    expect(userInfoResult?.status).toBe('warn')
+    expect(report.summary.warn).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/src/tests/features/oidc-preflight.test.ts
+++ b/src/tests/features/oidc-preflight.test.ts
@@ -1,10 +1,8 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { describe, expect, mock, test } from 'bun:test'
 import {
   fetchOidcDiscoveryConfiguration,
   runOidcEndpointPreflight,
 } from '@/features/oauthPlayground/utils/oidc-preflight'
-
-const originalFetch = globalThis.fetch
 
 function createJsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -13,34 +11,13 @@ function createJsonResponse(body: unknown, status = 200): Response {
   })
 }
 
-function resolveTargetUrl(input: Request | string): string {
-  const url = typeof input === 'string' ? input : input.url
-  const proxyPrefix = '/api/cors-proxy/'
-  const proxyIndex = url.indexOf(proxyPrefix)
-  if (proxyIndex === -1) {
-    return url
-  }
-
-  const encodedTarget = url.slice(proxyIndex + proxyPrefix.length)
-  return decodeURIComponent(encodedTarget)
-}
-
 function isDiscoveryUrl(target: string): boolean {
   return target.includes('/.well-known/openid-configuration')
 }
 
 describe('OIDC endpoint preflight', () => {
-  beforeEach(() => {
-    globalThis.fetch = mock(async () => createJsonResponse({ error: 'not mocked' }, 404)) as any
-  })
-
-  afterEach(() => {
-    globalThis.fetch = originalFetch
-  })
-
   test('fetches discovery document and normalizes issuer URL', async () => {
-    ;(globalThis.fetch as any).mockImplementation(async (input: Request | string) => {
-      const target = resolveTargetUrl(input)
+    const fetcher = mock(async (target: string) => {
       if (target.endsWith('/tenant/.well-known/openid-configuration')) {
         return createJsonResponse({
           issuer: 'https://issuer.example.com/tenant',
@@ -53,7 +30,7 @@ describe('OIDC endpoint preflight', () => {
       return createJsonResponse({}, 404)
     })
 
-    const result = await fetchOidcDiscoveryConfiguration('issuer.example.com/tenant/')
+    const result = await fetchOidcDiscoveryConfiguration('issuer.example.com/tenant/', fetcher)
 
     expect(result.normalizedIssuerUrl).toBe('https://issuer.example.com/tenant')
     expect(result.discoveryUrl).toBe(
@@ -63,8 +40,7 @@ describe('OIDC endpoint preflight', () => {
   })
 
   test('fails discovery when discovery endpoint is not successful', async () => {
-    ;(globalThis.fetch as any).mockImplementation(async (input: Request | string) => {
-      const target = resolveTargetUrl(input)
+    const fetcher = mock(async (target: string) => {
       if (isDiscoveryUrl(target)) {
         return createJsonResponse({ error: 'unavailable' }, 503)
       }
@@ -72,15 +48,13 @@ describe('OIDC endpoint preflight', () => {
       return createJsonResponse({}, 404)
     })
 
-    await expect(fetchOidcDiscoveryConfiguration('https://issuer.example.com')).rejects.toThrow(
-      /OIDC discovery failed: 503/
-    )
+    await expect(
+      fetchOidcDiscoveryConfiguration('https://issuer.example.com', fetcher)
+    ).rejects.toThrow(/OIDC discovery failed: 503/)
   })
 
   test('classifies endpoint probe results across status classes', async () => {
-    ;(globalThis.fetch as any).mockImplementation(async (input: Request | string) => {
-      const target = resolveTargetUrl(input)
-
+    const fetcher = mock(async (target: string) => {
       if (isDiscoveryUrl(target)) {
         return createJsonResponse({
           issuer: 'https://issuer.example.com',
@@ -111,7 +85,10 @@ describe('OIDC endpoint preflight', () => {
       return createJsonResponse({}, 404)
     })
 
-    const report = await runOidcEndpointPreflight({ issuerUrl: 'https://issuer.example.com' })
+    const report = await runOidcEndpointPreflight(
+      { issuerUrl: 'https://issuer.example.com' },
+      fetcher
+    )
     const statuses = Object.fromEntries(
       report.endpoints.map((entry) => [entry.endpoint, entry.status])
     )
@@ -125,9 +102,7 @@ describe('OIDC endpoint preflight', () => {
   })
 
   test('marks network, CORS, and timeout probe failures as warnings', async () => {
-    ;(globalThis.fetch as any).mockImplementation(async (input: Request | string) => {
-      const target = resolveTargetUrl(input)
-
+    const fetcher = mock(async (target: string) => {
       if (isDiscoveryUrl(target)) {
         return createJsonResponse({
           issuer: 'https://issuer.example.com',
@@ -150,10 +125,13 @@ describe('OIDC endpoint preflight', () => {
       return createJsonResponse({}, 200)
     })
 
-    const report = await runOidcEndpointPreflight({
-      issuerUrl: 'https://issuer.example.com',
-      timeoutMs: 5,
-    })
+    const report = await runOidcEndpointPreflight(
+      {
+        issuerUrl: 'https://issuer.example.com',
+        timeoutMs: 5,
+      },
+      fetcher
+    )
 
     const tokenResult = report.endpoints.find((entry) => entry.endpoint === 'token_endpoint')
     const userInfoResult = report.endpoints.find((entry) => entry.endpoint === 'userinfo_endpoint')

--- a/src/tests/hooks/use-oidc-config.test.tsx
+++ b/src/tests/hooks/use-oidc-config.test.tsx
@@ -3,33 +3,8 @@ import { act, renderHook } from '@testing-library/react'
 import { useOidcConfig } from '@/hooks/data-fetching/useOidcConfig'
 import { oidcConfigCache } from '@/lib/cache/oidc-config-cache'
 
-const originalFetch = globalThis.fetch
-
-function createJsonResponse(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
-}
-
-function resolveTargetUrl(input: Request | string): string {
-  const url = typeof input === 'string' ? input : input.url
-  const proxyPrefix = '/api/cors-proxy/'
-  const proxyIndex = url.indexOf(proxyPrefix)
-  if (proxyIndex === -1) {
-    return url
-  }
-
-  const encodedTarget = url.slice(proxyIndex + proxyPrefix.length)
-  return decodeURIComponent(encodedTarget)
-}
-
-function isTenantDiscoveryUrl(target: string): boolean {
-  return target.endsWith('/tenant/.well-known/openid-configuration')
-}
-
-function isIssuerDiscoveryUrl(target: string): boolean {
-  return target.includes('/.well-known/openid-configuration')
+function isTenantIssuerUrl(target: string): boolean {
+  return target === 'https://issuer.example.com/tenant'
 }
 
 describe('useOidcConfig', () => {
@@ -39,28 +14,27 @@ describe('useOidcConfig', () => {
 
   afterEach(() => {
     oidcConfigCache.clear()
-    globalThis.fetch = originalFetch
   })
 
   test('normalizes issuer URLs and reuses cached discovery responses', async () => {
     const fetchCalls: string[] = []
-    globalThis.fetch = mock(async (input: Request | string) => {
-      const target = resolveTargetUrl(input)
-      fetchCalls.push(target)
-
-      if (isTenantDiscoveryUrl(target)) {
-        return createJsonResponse({
-          issuer: 'https://issuer.example.com/tenant',
-          authorization_endpoint: 'https://issuer.example.com/tenant/oauth2/authorize',
-          token_endpoint: 'https://issuer.example.com/tenant/oauth2/token',
-          jwks_uri: 'https://issuer.example.com/tenant/oauth2/jwks',
-        })
+    const fetchDiscoveryConfiguration = mock(async (issuerUrl: string) => {
+      fetchCalls.push(issuerUrl)
+      return {
+        normalizedIssuerUrl: issuerUrl,
+        discoveryUrl: `${issuerUrl}/.well-known/openid-configuration`,
+        config: {
+          issuer: issuerUrl,
+          authorization_endpoint: `${issuerUrl}/oauth2/authorize`,
+          token_endpoint: `${issuerUrl}/oauth2/token`,
+          jwks_uri: `${issuerUrl}/oauth2/jwks`,
+        },
+        status: 200,
+        statusText: 'OK',
       }
+    })
 
-      return createJsonResponse({ error: 'not found' }, 404)
-    }) as any
-
-    const { result } = renderHook(() => useOidcConfig())
+    const { result } = renderHook(() => useOidcConfig({ fetchDiscoveryConfiguration }))
 
     await act(async () => {
       await result.current.fetchConfig('issuer.example.com/tenant/')
@@ -68,7 +42,7 @@ describe('useOidcConfig', () => {
 
     expect(result.current.data?.issuer).toBe('https://issuer.example.com/tenant')
     expect(result.current.currentIssuer).toBe('https://issuer.example.com/tenant')
-    expect(fetchCalls.some((target) => isTenantDiscoveryUrl(target))).toBe(true)
+    expect(fetchCalls.some((target) => isTenantIssuerUrl(target))).toBe(true)
 
     await act(async () => {
       await result.current.fetchConfig('https://issuer.example.com/tenant')
@@ -79,16 +53,11 @@ describe('useOidcConfig', () => {
   })
 
   test('captures response errors from discovery fetch failures', async () => {
-    globalThis.fetch = mock(async (input: Request | string) => {
-      const target = resolveTargetUrl(input)
-      if (isIssuerDiscoveryUrl(target)) {
-        return createJsonResponse({ error: 'server unavailable' }, 500)
-      }
+    const fetchDiscoveryConfiguration = mock(async () => {
+      throw new Error('OIDC discovery failed: 500 Internal Server Error')
+    })
 
-      return createJsonResponse({ error: 'not found' }, 404)
-    }) as any
-
-    const { result } = renderHook(() => useOidcConfig())
+    const { result } = renderHook(() => useOidcConfig({ fetchDiscoveryConfiguration }))
 
     await act(async () => {
       await result.current.fetchConfig('https://issuer.example.com')
@@ -100,16 +69,16 @@ describe('useOidcConfig', () => {
   })
 
   test('handles invalid issuer URLs without attempting discovery', async () => {
-    const fetchMock = mock(async () => createJsonResponse({}))
-    globalThis.fetch = fetchMock as any
-
-    const { result } = renderHook(() => useOidcConfig())
+    const fetchDiscoveryConfiguration = mock(async () => {
+      throw new Error('Discovery should not be called')
+    })
+    const { result } = renderHook(() => useOidcConfig({ fetchDiscoveryConfiguration }))
 
     await act(async () => {
       await result.current.fetchConfig('%%%%')
     })
 
-    expect(fetchMock).toHaveBeenCalledTimes(0)
+    expect(fetchDiscoveryConfiguration).toHaveBeenCalledTimes(0)
     expect(result.current.data).toBeNull()
     expect(result.current.error?.message).toContain('Invalid Issuer URL format.')
   })

--- a/src/tests/hooks/use-oidc-config.test.tsx
+++ b/src/tests/hooks/use-oidc-config.test.tsx
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { useOidcConfig } from '@/hooks/data-fetching/useOidcConfig'
+import { oidcConfigCache } from '@/lib/cache/oidc-config-cache'
+
+const originalFetch = globalThis.fetch
+
+function createJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function resolveTargetUrl(input: Request | string): string {
+  const url = typeof input === 'string' ? input : input.url
+  const proxyPrefix = '/api/cors-proxy/'
+  const proxyIndex = url.indexOf(proxyPrefix)
+  if (proxyIndex === -1) {
+    return url
+  }
+
+  const encodedTarget = url.slice(proxyIndex + proxyPrefix.length)
+  return decodeURIComponent(encodedTarget)
+}
+
+describe('useOidcConfig', () => {
+  beforeEach(() => {
+    oidcConfigCache.clear()
+  })
+
+  afterEach(() => {
+    oidcConfigCache.clear()
+    globalThis.fetch = originalFetch
+  })
+
+  test('normalizes issuer URLs and reuses cached discovery responses', async () => {
+    const fetchCalls: string[] = []
+    globalThis.fetch = mock(async (input: Request | string) => {
+      const target = resolveTargetUrl(input)
+      fetchCalls.push(target)
+
+      if (target === 'https://issuer.example.com/tenant/.well-known/openid-configuration') {
+        return createJsonResponse({
+          issuer: 'https://issuer.example.com/tenant',
+          authorization_endpoint: 'https://issuer.example.com/tenant/oauth2/authorize',
+          token_endpoint: 'https://issuer.example.com/tenant/oauth2/token',
+          jwks_uri: 'https://issuer.example.com/tenant/oauth2/jwks',
+        })
+      }
+
+      return createJsonResponse({ error: 'not found' }, 404)
+    }) as any
+
+    const { result } = renderHook(() => useOidcConfig())
+
+    await act(async () => {
+      await result.current.fetchConfig('issuer.example.com/tenant/')
+    })
+
+    await waitFor(() => {
+      expect(result.current.data?.issuer).toBe('https://issuer.example.com/tenant')
+    })
+    expect(result.current.currentIssuer).toBe('https://issuer.example.com/tenant')
+    expect(fetchCalls).toContain(
+      'https://issuer.example.com/tenant/.well-known/openid-configuration'
+    )
+
+    await act(async () => {
+      await result.current.fetchConfig('https://issuer.example.com/tenant')
+    })
+
+    expect(fetchCalls.length).toBe(1)
+    expect(result.current.error).toBeNull()
+  })
+
+  test('captures response errors from discovery fetch failures', async () => {
+    globalThis.fetch = mock(async (input: Request | string) => {
+      const target = resolveTargetUrl(input)
+      if (target === 'https://issuer.example.com/.well-known/openid-configuration') {
+        return createJsonResponse({ error: 'server unavailable' }, 500)
+      }
+
+      return createJsonResponse({ error: 'not found' }, 404)
+    }) as any
+
+    const { result } = renderHook(() => useOidcConfig())
+
+    await act(async () => {
+      await result.current.fetchConfig('https://issuer.example.com')
+    })
+
+    await waitFor(() => {
+      expect(result.current.error).toBeTruthy()
+    })
+
+    expect(result.current.data).toBeNull()
+    expect(result.current.error?.message).toContain('OIDC discovery failed: 500')
+  })
+
+  test('handles invalid issuer URLs without attempting discovery', async () => {
+    const fetchMock = mock(async () => createJsonResponse({}))
+    globalThis.fetch = fetchMock as any
+
+    const { result } = renderHook(() => useOidcConfig())
+
+    await act(async () => {
+      await result.current.fetchConfig('%%%%')
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(0)
+    expect(result.current.data).toBeNull()
+    expect(result.current.error?.message).toContain('Invalid Issuer URL format.')
+  })
+})

--- a/src/tests/hooks/use-oidc-config.test.tsx
+++ b/src/tests/hooks/use-oidc-config.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
-import { act, renderHook, waitFor } from '@testing-library/react'
+import { act, renderHook } from '@testing-library/react'
 import { useOidcConfig } from '@/hooks/data-fetching/useOidcConfig'
 import { oidcConfigCache } from '@/lib/cache/oidc-config-cache'
 
@@ -24,6 +24,14 @@ function resolveTargetUrl(input: Request | string): string {
   return decodeURIComponent(encodedTarget)
 }
 
+function isTenantDiscoveryUrl(target: string): boolean {
+  return target.endsWith('/tenant/.well-known/openid-configuration')
+}
+
+function isIssuerDiscoveryUrl(target: string): boolean {
+  return target.includes('/.well-known/openid-configuration')
+}
+
 describe('useOidcConfig', () => {
   beforeEach(() => {
     oidcConfigCache.clear()
@@ -40,7 +48,7 @@ describe('useOidcConfig', () => {
       const target = resolveTargetUrl(input)
       fetchCalls.push(target)
 
-      if (target === 'https://issuer.example.com/tenant/.well-known/openid-configuration') {
+      if (isTenantDiscoveryUrl(target)) {
         return createJsonResponse({
           issuer: 'https://issuer.example.com/tenant',
           authorization_endpoint: 'https://issuer.example.com/tenant/oauth2/authorize',
@@ -58,13 +66,9 @@ describe('useOidcConfig', () => {
       await result.current.fetchConfig('issuer.example.com/tenant/')
     })
 
-    await waitFor(() => {
-      expect(result.current.data?.issuer).toBe('https://issuer.example.com/tenant')
-    })
+    expect(result.current.data?.issuer).toBe('https://issuer.example.com/tenant')
     expect(result.current.currentIssuer).toBe('https://issuer.example.com/tenant')
-    expect(fetchCalls).toContain(
-      'https://issuer.example.com/tenant/.well-known/openid-configuration'
-    )
+    expect(fetchCalls.some((target) => isTenantDiscoveryUrl(target))).toBe(true)
 
     await act(async () => {
       await result.current.fetchConfig('https://issuer.example.com/tenant')
@@ -77,7 +81,7 @@ describe('useOidcConfig', () => {
   test('captures response errors from discovery fetch failures', async () => {
     globalThis.fetch = mock(async (input: Request | string) => {
       const target = resolveTargetUrl(input)
-      if (target === 'https://issuer.example.com/.well-known/openid-configuration') {
+      if (isIssuerDiscoveryUrl(target)) {
         return createJsonResponse({ error: 'server unavailable' }, 500)
       }
 
@@ -90,10 +94,7 @@ describe('useOidcConfig', () => {
       await result.current.fetchConfig('https://issuer.example.com')
     })
 
-    await waitFor(() => {
-      expect(result.current.error).toBeTruthy()
-    })
-
+    expect(result.current.error).toBeTruthy()
     expect(result.current.data).toBeNull()
     expect(result.current.error?.message).toContain('OIDC discovery failed: 500')
   })

--- a/src/tests/lib/worker.test.ts
+++ b/src/tests/lib/worker.test.ts
@@ -13,7 +13,9 @@ const fetchSpy = async (request: Request | string) => {
   })
 }
 
-const createEnv = (overrides: { CORS_ALLOWED_ORIGINS?: string } = {}) => ({
+const createEnv = (
+  overrides: { CORS_ALLOWED_ORIGINS?: string; DEMO_TOKEN_SIGNING_SECRET?: string } = {}
+) => ({
   ASSETS: {
     fetch: async () =>
       new Response('<html>ok</html>', {
@@ -26,6 +28,19 @@ const createEnv = (overrides: { CORS_ALLOWED_ORIGINS?: string } = {}) => ({
 
 const buildRequest = (path: string, init?: RequestInit) =>
   new Request(`https://app.test${path}`, init)
+
+const tamperToken = (value: string) => {
+  const parts = value.split('.')
+  if (parts.length === 3) {
+    const signature = parts[2]
+    const replacement = signature.endsWith('a') ? 'b' : 'a'
+    parts[2] = `${signature.slice(0, -1)}${replacement}`
+    return parts.join('.')
+  }
+
+  const replacement = value.endsWith('a') ? 'b' : 'a'
+  return `${value.slice(0, -1)}${replacement}`
+}
 
 describe('worker api', () => {
   beforeEach(() => {
@@ -154,5 +169,219 @@ describe('worker api', () => {
     if (CSP_INLINE_SCRIPT_SHA256) {
       expect(csp).toContain(CSP_INLINE_SCRIPT_SHA256)
     }
+  })
+
+  test('accepts signed auth code and rejects tampered auth code in strict mode', async () => {
+    const env = createEnv({ DEMO_TOKEN_SIGNING_SECRET: 'strict-signing-secret' })
+    const redirectUri = 'https://client.example.com/callback'
+
+    const authResponse = await worker.fetch(
+      buildRequest(
+        `/api/auth?response_type=code&client_id=demo-client&redirect_uri=${encodeURIComponent(redirectUri)}&scope=openid%20offline_access`
+      ),
+      env
+    )
+    expect(authResponse.status).toBe(302)
+
+    const location = authResponse.headers.get('Location')
+    expect(location).toBeTruthy()
+    const redirect = new URL(location!)
+    const authorizationCode = redirect.searchParams.get('code')
+    expect(authorizationCode).toBeTruthy()
+
+    const tokenRequestBody = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code: authorizationCode!,
+      redirect_uri: redirectUri,
+      client_id: 'demo-client',
+    }).toString()
+
+    const tokenResponse = await worker.fetch(
+      buildRequest('/api/token', {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: tokenRequestBody,
+      }),
+      env
+    )
+    expect(tokenResponse.status).toBe(200)
+    const tokenData = await tokenResponse.json()
+    expect(typeof tokenData.access_token).toBe('string')
+
+    const tamperedCode = tamperToken(authorizationCode!)
+    const tamperedTokenResponse = await worker.fetch(
+      buildRequest('/api/token', {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: 'authorization_code',
+          code: tamperedCode,
+          redirect_uri: redirectUri,
+          client_id: 'demo-client',
+        }).toString(),
+      }),
+      env
+    )
+    expect(tamperedTokenResponse.status).toBe(400)
+    const tamperedData = await tamperedTokenResponse.json()
+    expect(tamperedData.error).toBe('invalid_grant')
+  })
+
+  test('accepts signed refresh token and rejects tampered refresh token in strict mode', async () => {
+    const env = createEnv({ DEMO_TOKEN_SIGNING_SECRET: 'strict-signing-secret' })
+    const redirectUri = 'https://client.example.com/callback'
+
+    const authResponse = await worker.fetch(
+      buildRequest(
+        `/api/auth?response_type=code&client_id=demo-client&redirect_uri=${encodeURIComponent(redirectUri)}&scope=openid%20offline_access`
+      ),
+      env
+    )
+    const authLocation = authResponse.headers.get('Location')
+    const authCode = authLocation ? new URL(authLocation).searchParams.get('code') : null
+    expect(authCode).toBeTruthy()
+
+    const exchangeResponse = await worker.fetch(
+      buildRequest('/api/token', {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: 'authorization_code',
+          code: authCode!,
+          redirect_uri: redirectUri,
+          client_id: 'demo-client',
+        }).toString(),
+      }),
+      env
+    )
+    const exchangeData = await exchangeResponse.json()
+    expect(exchangeResponse.status).toBe(200)
+    expect(typeof exchangeData.refresh_token).toBe('string')
+
+    const refreshResponse = await worker.fetch(
+      buildRequest('/api/token', {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: 'refresh_token',
+          refresh_token: exchangeData.refresh_token,
+          client_id: 'demo-client',
+        }).toString(),
+      }),
+      env
+    )
+    expect(refreshResponse.status).toBe(200)
+    const refreshedData = await refreshResponse.json()
+    expect(typeof refreshedData.access_token).toBe('string')
+
+    const tamperedRefreshToken = tamperToken(exchangeData.refresh_token)
+    const invalidRefreshResponse = await worker.fetch(
+      buildRequest('/api/token', {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: 'refresh_token',
+          refresh_token: tamperedRefreshToken,
+          client_id: 'demo-client',
+        }).toString(),
+      }),
+      env
+    )
+    expect(invalidRefreshResponse.status).toBe(400)
+    const invalidRefreshData = await invalidRefreshResponse.json()
+    expect(invalidRefreshData.error).toBe('invalid_grant')
+  })
+
+  test('rejects invalid JWT signatures for userinfo and introspection in strict mode', async () => {
+    const env = createEnv({ DEMO_TOKEN_SIGNING_SECRET: 'strict-signing-secret' })
+
+    const tokenGenerationResponse = await worker.fetch(
+      buildRequest('/api/token/generate', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          subject: 'demo-user',
+          client_id: 'demo-client',
+          scope: 'openid profile email',
+        }),
+      }),
+      env
+    )
+    expect(tokenGenerationResponse.status).toBe(200)
+    const generatedToken = await tokenGenerationResponse.json()
+    const tamperedAccessToken = tamperToken(generatedToken.access_token)
+
+    const userInfoResponse = await worker.fetch(
+      buildRequest('/api/userinfo', {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${tamperedAccessToken}` },
+      }),
+      env
+    )
+    expect(userInfoResponse.status).toBe(401)
+    const userInfoData = await userInfoResponse.json()
+    expect(userInfoData.error).toBe('invalid_token')
+
+    const introspectionResponse = await worker.fetch(
+      buildRequest('/api/introspect', {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ token: tamperedAccessToken }).toString(),
+      }),
+      env
+    )
+    expect(introspectionResponse.status).toBe(200)
+    const introspectionData = await introspectionResponse.json()
+    expect(introspectionData.active).toBe(false)
+  })
+
+  test('keeps legacy auth-code and refresh-token behavior when strict secret is unset', async () => {
+    const env = createEnv()
+    const redirectUri = 'https://client.example.com/callback'
+
+    const authResponse = await worker.fetch(
+      buildRequest(
+        `/api/auth?response_type=code&client_id=demo-client&redirect_uri=${encodeURIComponent(redirectUri)}&scope=openid%20offline_access`
+      ),
+      env
+    )
+    expect(authResponse.status).toBe(302)
+    const authLocation = authResponse.headers.get('Location')
+    const authCode = authLocation ? new URL(authLocation).searchParams.get('code') : null
+    expect(authCode).toBeTruthy()
+
+    const exchangeResponse = await worker.fetch(
+      buildRequest('/api/token', {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: 'authorization_code',
+          code: authCode!,
+          redirect_uri: redirectUri,
+          client_id: 'demo-client',
+        }).toString(),
+      }),
+      env
+    )
+    expect(exchangeResponse.status).toBe(200)
+    const exchangeData = await exchangeResponse.json()
+    expect(typeof exchangeData.refresh_token).toBe('string')
+    expect(exchangeData.refresh_token.startsWith('rt_')).toBe(true)
+
+    const refreshResponse = await worker.fetch(
+      buildRequest('/api/token', {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: 'refresh_token',
+          refresh_token: exchangeData.refresh_token,
+          client_id: 'demo-client',
+        }).toString(),
+      }),
+      env
+    )
+    expect(refreshResponse.status).toBe(200)
+    const refreshedData = await refreshResponse.json()
+    expect(typeof refreshedData.access_token).toBe('string')
   })
 })

--- a/src/tests/lib/worker.test.ts
+++ b/src/tests/lib/worker.test.ts
@@ -29,17 +29,26 @@ const createEnv = (
 const buildRequest = (path: string, init?: RequestInit) =>
   new Request(`https://app.test${path}`, init)
 
+const mutateSegment = (segment: string): string => {
+  if (!segment) {
+    return 'A'
+  }
+
+  // Avoid mutating the final base64url character where padding bits can be ignored.
+  const indexToMutate = segment.length > 1 ? 1 : 0
+  const current = segment[indexToMutate]
+  const replacement = current === 'A' ? 'B' : 'A'
+  return `${segment.slice(0, indexToMutate)}${replacement}${segment.slice(indexToMutate + 1)}`
+}
+
 const tamperToken = (value: string) => {
   const parts = value.split('.')
   if (parts.length === 3) {
-    const signature = parts[2]
-    const replacement = signature.endsWith('a') ? 'b' : 'a'
-    parts[2] = `${signature.slice(0, -1)}${replacement}`
+    parts[2] = mutateSegment(parts[2])
     return parts.join('.')
   }
 
-  const replacement = value.endsWith('a') ? 'b' : 'a'
-  return `${value.slice(0, -1)}${replacement}`
+  return mutateSegment(value)
 }
 
 describe('worker api', () => {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -9,6 +9,7 @@ type AssetsBinding = { fetch: (request: Request) => Promise<Response> }
 interface Env {
   ASSETS: AssetsBinding
   CORS_ALLOWED_ORIGINS?: string
+  DEMO_TOKEN_SIGNING_SECRET?: string
 }
 
 type RateLimitBucket = { count: number; resetAt: number }
@@ -17,6 +18,10 @@ type RateLimitConfig = { max: number; windowMs: number }
 const rateLimitBuckets = new Map<string, RateLimitBucket>()
 const CORS_PROXY_RATE_LIMIT: RateLimitConfig = { max: 60, windowMs: 60_000 }
 const DEMO_RATE_LIMIT: RateLimitConfig = { max: 120, windowMs: 60_000 }
+const SIGNED_ENVELOPE_VERSION = 'v1'
+const DEMO_JWT_KID = DEMO_JWKS.keys[0]?.kid
+const hmacKeyCache = new Map<string, Promise<CryptoKey>>()
+let demoJwtVerifyKeyPromise: Promise<CryptoKey> | null = null
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
@@ -391,7 +396,7 @@ async function handleAuthorization(request: Request, env: Env): Promise<Response
     exp: now + AUTH_CODE_TTL,
   }
 
-  const code = encodeAuthCode(payload)
+  const code = await encodeAuthCode(payload, env)
   const redirect = new URL(redirectUri)
   redirect.searchParams.set('code', code)
   if (state) {
@@ -429,7 +434,7 @@ async function handleToken(request: Request, env: Env): Promise<Response> {
       return oauthError('invalid_request', 'code and redirect_uri are required', request, env)
     }
 
-    const authCode = decodeAuthCode(code)
+    const authCode = await decodeAuthCode(code, env)
     if (!authCode) {
       return oauthError('invalid_grant', 'Authorization code is invalid', request, env)
     }
@@ -472,6 +477,7 @@ async function handleToken(request: Request, env: Env): Promise<Response> {
     )
     const scopeList = splitScopes(resolvedScope)
     const tokenResponse = await issueTokenResponse({
+      env,
       issuer,
       clientId,
       subject: authCode.sub,
@@ -491,7 +497,7 @@ async function handleToken(request: Request, env: Env): Promise<Response> {
       return oauthError('invalid_request', 'refresh_token is required', request, env)
     }
 
-    const refreshPayload = decodeRefreshToken(refreshToken)
+    const refreshPayload = await decodeRefreshToken(refreshToken, env)
     if (!refreshPayload) {
       return oauthError('invalid_grant', 'refresh_token is invalid', request, env)
     }
@@ -515,6 +521,7 @@ async function handleToken(request: Request, env: Env): Promise<Response> {
     )
     const scopeList = splitScopes(resolvedScope)
     const tokenResponse = await issueTokenResponse({
+      env,
       issuer,
       clientId,
       subject: refreshPayload.sub,
@@ -530,6 +537,7 @@ async function handleToken(request: Request, env: Env): Promise<Response> {
   if (grantType === 'client_credentials') {
     const resolvedScope = normalizeScope(getString(params, 'scope') || DEFAULT_API_SCOPE)
     const tokenResponse = await issueTokenResponse({
+      env,
       issuer,
       clientId,
       subject: clientId,
@@ -605,6 +613,13 @@ async function handleUserInfo(request: Request, env: Env): Promise<Response> {
     return oauthError('invalid_token', 'Token is not a valid JWT', request, env, 401)
   }
 
+  if (isDemoJwtCandidate(token, payload, request)) {
+    const signatureValid = await verifyDemoJwtSignature(token)
+    if (!signatureValid) {
+      return oauthError('invalid_token', 'Token signature is invalid', request, env, 401)
+    }
+  }
+
   if (!isTokenActive(payload)) {
     return oauthError('invalid_token', 'Token has expired', request, env, 401)
   }
@@ -630,7 +645,14 @@ async function handleIntrospection(request: Request, env: Env): Promise<Response
   }
 
   const jwtPayload = decodeJwtPayload(token)
-  const refreshPayload = jwtPayload ? null : decodeRefreshToken(token)
+  if (jwtPayload && isDemoJwtCandidate(token, jwtPayload, request)) {
+    const signatureValid = await verifyDemoJwtSignature(token)
+    if (!signatureValid) {
+      return oauthJson({ active: false }, undefined, request, env)
+    }
+  }
+
+  const refreshPayload = jwtPayload ? null : await decodeRefreshToken(token, env)
   const payload = (jwtPayload || refreshPayload) as Record<string, unknown>
 
   if (!payload) {
@@ -741,6 +763,7 @@ function oauthError(
 }
 
 async function issueTokenResponse(opts: {
+  env: Env
   issuer: string
   clientId: string
   subject: string
@@ -788,13 +811,16 @@ async function issueTokenResponse(opts: {
   }
 
   if (opts.includeRefreshToken) {
-    response.refresh_token = encodeRefreshToken({
-      client_id: opts.clientId,
-      sub: opts.subject,
-      scope: opts.scope,
-      issued_at: now,
-      exp: now + REFRESH_TOKEN_TTL,
-    })
+    response.refresh_token = await encodeRefreshToken(
+      {
+        client_id: opts.clientId,
+        sub: opts.subject,
+        scope: opts.scope,
+        issued_at: now,
+        exp: now + REFRESH_TOKEN_TTL,
+      },
+      opts.env
+    )
   }
 
   return response
@@ -815,21 +841,41 @@ function splitScopes(scope: string): string[] {
   return scope.split(/\s+/).filter(Boolean)
 }
 
-function encodeAuthCode(payload: AuthCodePayload): string {
-  return encodeJson(payload)
+async function encodeAuthCode(payload: AuthCodePayload, env: Env): Promise<string> {
+  const secret = getDemoTokenSigningSecret(env)
+  if (!secret) {
+    return encodeJson(payload)
+  }
+
+  return await encodeSignedEnvelope(payload, secret)
 }
 
-function decodeAuthCode(value: string): AuthCodePayload | null {
-  return decodeJson<AuthCodePayload>(value)
+async function decodeAuthCode(value: string, env: Env): Promise<AuthCodePayload | null> {
+  const secret = getDemoTokenSigningSecret(env)
+  if (!secret) {
+    return decodeJson<AuthCodePayload>(value)
+  }
+
+  return await decodeSignedEnvelope<AuthCodePayload>(value, secret)
 }
 
-function encodeRefreshToken(payload: RefreshTokenPayload): string {
-  return `rt_${encodeJson(payload)}`
+async function encodeRefreshToken(payload: RefreshTokenPayload, env: Env): Promise<string> {
+  const secret = getDemoTokenSigningSecret(env)
+  if (!secret) {
+    return `rt_${encodeJson(payload)}`
+  }
+
+  return await encodeSignedEnvelope(payload, secret)
 }
 
-function decodeRefreshToken(token: string): RefreshTokenPayload | null {
-  const raw = token.startsWith('rt_') ? token.slice(3) : token
-  return decodeJson<RefreshTokenPayload>(raw)
+async function decodeRefreshToken(token: string, env: Env): Promise<RefreshTokenPayload | null> {
+  const secret = getDemoTokenSigningSecret(env)
+  if (!secret) {
+    const raw = token.startsWith('rt_') ? token.slice(3) : token
+    return decodeJson<RefreshTokenPayload>(raw)
+  }
+
+  return await decodeSignedEnvelope<RefreshTokenPayload>(token, secret)
 }
 
 function extractBearerToken(headers: Headers): string | null {
@@ -844,6 +890,58 @@ function decodeJwtPayload(token: string): Record<string, unknown> | null {
   const parts = token.split('.')
   if (parts.length < 2) return null
   return decodeJson<Record<string, unknown>>(parts[1])
+}
+
+function decodeJwtHeader(token: string): Record<string, unknown> | null {
+  const parts = token.split('.')
+  if (parts.length < 1) return null
+  return decodeJson<Record<string, unknown>>(parts[0])
+}
+
+function isDemoJwtCandidate(
+  token: string,
+  payload: Record<string, unknown>,
+  request: Request
+): boolean {
+  const header = decodeJwtHeader(token)
+  const headerKid = typeof header?.kid === 'string' ? header.kid : undefined
+  const issuer = typeof payload.iss === 'string' ? payload.iss : undefined
+  const requestIssuer = getIssuer(request)
+  const hasDemoMarker = payload.is_demo_token === true
+
+  return Boolean(headerKid === DEMO_JWT_KID || hasDemoMarker || issuer === requestIssuer)
+}
+
+async function verifyDemoJwtSignature(token: string): Promise<boolean> {
+  try {
+    const [header, payload, signature] = token.split('.')
+    if (!header || !payload || !signature) return false
+
+    const key = await getDemoJwtVerifyKey()
+    const data = new TextEncoder().encode(`${header}.${payload}`)
+    const signatureBytes = base64UrlDecode(signature)
+
+    return await crypto.subtle.verify('RSASSA-PKCS1-v1_5', key, toArrayBuffer(signatureBytes), data)
+  } catch {
+    return false
+  }
+}
+
+async function getDemoJwtVerifyKey(): Promise<CryptoKey> {
+  if (!demoJwtVerifyKeyPromise) {
+    demoJwtVerifyKeyPromise = crypto.subtle.importKey(
+      'jwk',
+      DEMO_JWKS.keys[0] as JsonWebKey,
+      {
+        name: 'RSASSA-PKCS1-v1_5',
+        hash: { name: 'SHA-256' },
+      },
+      false,
+      ['verify']
+    )
+  }
+
+  return await demoJwtVerifyKeyPromise
 }
 
 function isTokenActive(payload: Record<string, unknown>): boolean {
@@ -970,6 +1068,70 @@ function getIssuer(request: Request): string {
   return `${url.protocol}//${url.host}/api`
 }
 
+function getDemoTokenSigningSecret(env: Env): string | null {
+  const secret = env.DEMO_TOKEN_SIGNING_SECRET?.trim()
+  return secret ? secret : null
+}
+
+async function encodeSignedEnvelope(payload: unknown, secret: string): Promise<string> {
+  const encodedPayload = encodeJson(payload)
+  const signingInput = `${SIGNED_ENVELOPE_VERSION}.${encodedPayload}`
+  const signature = await createHmacSignature(signingInput, secret)
+  return `${SIGNED_ENVELOPE_VERSION}.${encodedPayload}.${signature}`
+}
+
+async function decodeSignedEnvelope<T>(value: string, secret: string): Promise<T | null> {
+  const parts = value.split('.')
+  if (parts.length !== 3) return null
+
+  const [version, encodedPayload, signature] = parts
+  if (version !== SIGNED_ENVELOPE_VERSION) return null
+  if (!encodedPayload || !signature) return null
+
+  const signingInput = `${version}.${encodedPayload}`
+  const expectedSignature = await createHmacSignature(signingInput, secret)
+  if (!constantTimeEqual(signature, expectedSignature)) {
+    return null
+  }
+
+  return decodeJson<T>(encodedPayload)
+}
+
+async function createHmacSignature(value: string, secret: string): Promise<string> {
+  const key = await getHmacSigningKey(secret)
+  const data = new TextEncoder().encode(value)
+  const signature = await crypto.subtle.sign('HMAC', key, data)
+  return base64UrlEncode(new Uint8Array(signature))
+}
+
+async function getHmacSigningKey(secret: string): Promise<CryptoKey> {
+  let keyPromise = hmacKeyCache.get(secret)
+  if (!keyPromise) {
+    keyPromise = crypto.subtle.importKey(
+      'raw',
+      new TextEncoder().encode(secret),
+      { name: 'HMAC', hash: { name: 'SHA-256' } },
+      false,
+      ['sign']
+    )
+    hmacKeyCache.set(secret, keyPromise)
+  }
+  return await keyPromise
+}
+
+function constantTimeEqual(left: string, right: string): boolean {
+  if (left.length !== right.length) {
+    return false
+  }
+
+  let mismatch = 0
+  for (let i = 0; i < left.length; i += 1) {
+    mismatch |= left.charCodeAt(i) ^ right.charCodeAt(i)
+  }
+
+  return mismatch === 0
+}
+
 function encodeJson(value: unknown): string {
   const json = JSON.stringify(value)
   return base64UrlEncode(new TextEncoder().encode(json))
@@ -995,6 +1157,10 @@ function base64UrlDecode(value: string): Uint8Array {
   const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=')
   const binary = atob(padded)
   return Uint8Array.from(binary, (c) => c.charCodeAt(0))
+}
+
+function toArrayBuffer(data: Uint8Array): ArrayBuffer {
+  return data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer
 }
 
 async function computeCodeChallenge(verifier: string): Promise<string> {


### PR DESCRIPTION
Summary
- add lint gate to CI and resolve lint failures in CSP hash, JWT helpers, config utilities, and the OIDC explorer hook
- harden demo-mode worker tokens with optional signing, verify JWTs in sensitive endpoints, and route JWT generation through shared signing logic with limited logging
- add OIDC endpoint preflight utility/component, reuse shared discovery logic, and document the new workflow for OAuth pages and docs
Testing
- Not run (not requested)