### PR TITLE
chore: refresh repo health and ui

### DIFF
--- a/e2e/tests/navigation.e2e.ts
+++ b/e2e/tests/navigation.e2e.ts
@@ -12,21 +12,24 @@ test.describe('Navigation and Homepage', () => {
 
   test('should load homepage', async ({ page }) => {
     await expect(page).toHaveTitle(/iam\.tools/)
-    await expect(page.locator('text=Welcome to IAM Tools')).toBeVisible()
-    await expect(page.locator('text=A collection of specialized tools')).toBeVisible()
+    await expect(page.locator('text=IAM Tools')).toBeVisible()
+    await expect(page.locator('text=A focused workbench')).toBeVisible()
   })
 
   test('should display all tool cards on homepage', async ({ page }) => {
     // Token Inspector card
-    await expect(page.locator(selectors.home.tokenInspector)).toBeVisible()
-    await expect(page.locator('text=Analyze JWT tokens')).toBeVisible()
+    const tokenInspectorCard = page.locator(selectors.home.tokenInspector)
+    await expect(tokenInspectorCard).toBeVisible()
+    await expect(tokenInspectorCard).toContainText('Decode JWTs, validate signatures')
 
     // OIDC Explorer card
-    await expect(page.locator(selectors.home.oidcExplorer)).toBeVisible()
-    await expect(page.locator('text=Explore OpenID Connect discovery documents')).toBeVisible()
+    const oidcExplorerCard = page.locator(selectors.home.oidcExplorer)
+    await expect(oidcExplorerCard).toBeVisible()
+    await expect(oidcExplorerCard).toContainText('Fetch discovery documents')
 
-    await expect(page.locator(selectors.home.oauthPlayground)).toBeVisible()
-    await expect(page.locator('text=Test and explore OAuth 2.0 flows')).toBeVisible()
+    const oauthPlaygroundCard = page.locator(selectors.home.oauthPlayground)
+    await expect(oauthPlaygroundCard).toBeVisible()
+    await expect(oauthPlaygroundCard).toContainText('Exercise auth code with PKCE')
   })
 
   test('should navigate to Token Inspector', async ({ page }) => {

--- a/src/components/common/EnvironmentProfileDialog.tsx
+++ b/src/components/common/EnvironmentProfileDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { normalizeIssuerUrl } from '@/features/oauthPlayground/utils/oidc-preflight'
 import { Button } from '@/components/ui/button'
 import {
@@ -44,6 +44,11 @@ interface EnvironmentProfileFormErrors {
   userInfoEndpoint?: string
 }
 
+interface EnvironmentProfileDialogResetSource {
+  open: boolean
+  initialProfile?: Partial<EnvironmentProfile | EnvironmentProfileDraft> | null
+}
+
 function getInitialFormState(
   initialProfile?: Partial<EnvironmentProfile | EnvironmentProfileDraft> | null
 ): EnvironmentProfileFormState {
@@ -87,19 +92,24 @@ export function EnvironmentProfileDialog({
   submitLabel,
   onSave,
 }: EnvironmentProfileDialogProps) {
-  const [formState, setFormState] = useState<EnvironmentProfileFormState>(
+  const [formState, setFormState] = useState<EnvironmentProfileFormState>(() =>
     getInitialFormState(initialProfile)
   )
   const [errors, setErrors] = useState<EnvironmentProfileFormErrors>({})
+  const [lastResetSource, setLastResetSource] = useState<EnvironmentProfileDialogResetSource>(
+    () => ({
+      open,
+      initialProfile,
+    })
+  )
 
-  useEffect(() => {
-    if (!open) {
-      return
-    }
-
+  if (open && (!lastResetSource.open || initialProfile !== lastResetSource.initialProfile)) {
+    setLastResetSource({ open, initialProfile })
     setFormState(getInitialFormState(initialProfile))
     setErrors({})
-  }, [initialProfile, open])
+  } else if (!open && lastResetSource.open) {
+    setLastResetSource({ open, initialProfile })
+  }
 
   const updateField = (field: keyof EnvironmentProfileFormState, value: string) => {
     setFormState((currentState) => ({ ...currentState, [field]: value }))

--- a/src/components/common/EnvironmentProfileSelector.tsx
+++ b/src/components/common/EnvironmentProfileSelector.tsx
@@ -23,6 +23,15 @@ interface EnvironmentProfileSelectorProps {
   buttonVariant?: 'default' | 'input-group'
 }
 
+interface EnvironmentSelectorTriggerProps {
+  buttonVariant: 'default' | 'input-group'
+  compact: boolean
+  configLoading: boolean
+  disabled: boolean
+  label: string
+  onClick?: () => void
+}
+
 function truncateUrl(url: string, maxLength: number = 44): string {
   if (url.length <= maxLength) {
     return url
@@ -41,6 +50,128 @@ function truncateUrl(url: string, maxLength: number = 44): string {
   } catch {
     return `${url.slice(0, maxLength - 3)}...`
   }
+}
+
+function EnvironmentProfileSummary({ profile }: { profile: EnvironmentProfile }) {
+  return (
+    <div className="flex min-w-0 flex-1 flex-col gap-1">
+      <div className="flex items-center gap-1 text-sm font-medium">
+        <Globe size={14} className="flex-shrink-0" />
+        <span className="truncate">{profile.name}</span>
+      </div>
+      <div className="truncate text-xs text-muted-foreground" title={profile.issuerUrl}>
+        {truncateUrl(profile.issuerUrl)}
+      </div>
+      <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+        {profile.clientId && <span>Client: {profile.clientId}</span>}
+        {profile.scopes.length > 0 && <span>Scopes: {profile.scopes.join(' ')}</span>}
+      </div>
+      <div className="flex items-center gap-1 text-xs text-muted-foreground">
+        <Clock size={12} />
+        {formatDistanceToNow(new Date(profile.lastUsedAt), { addSuffix: true })}
+      </div>
+    </div>
+  )
+}
+
+function EnvironmentProfileActions({
+  profile,
+  onEdit,
+  onDelete,
+}: {
+  profile: EnvironmentProfile
+  onEdit: (profile: EnvironmentProfile) => void
+  onDelete: (profile: EnvironmentProfile) => void
+}) {
+  return (
+    <div className="flex flex-shrink-0 items-center gap-1">
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-6 w-6"
+        aria-label={`Edit ${profile.name}`}
+        onClick={(event) => {
+          event.stopPropagation()
+          onEdit(profile)
+        }}
+      >
+        <Edit size={14} />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-6 w-6"
+        aria-label={`Delete ${profile.name}`}
+        onClick={(event) => {
+          event.stopPropagation()
+          onDelete(profile)
+        }}
+      >
+        <Trash2 size={14} />
+      </Button>
+    </div>
+  )
+}
+
+function EnvironmentSelectorTrigger({
+  buttonVariant,
+  compact,
+  configLoading,
+  disabled,
+  label,
+  onClick,
+}: EnvironmentSelectorTriggerProps) {
+  if (buttonVariant === 'input-group') {
+    return (
+      <InputGroupButton
+        type="button"
+        size="sm"
+        variant="outline"
+        grouped={false}
+        className="flex items-center gap-1.5"
+        disabled={disabled || configLoading}
+        aria-label={label}
+        data-testid="environment-selector-trigger"
+        onClick={onClick}
+      >
+        {configLoading ? <Loader2 size={16} className="animate-spin" /> : <Bookmark size={16} />}
+        <span className="hidden sm:inline">{label}</span>
+      </InputGroupButton>
+    )
+  }
+
+  if (compact) {
+    return (
+      <Button
+        variant="ghost"
+        size="icon"
+        type="button"
+        className="h-9 w-9"
+        disabled={disabled || configLoading}
+        aria-label={label}
+        data-testid="environment-selector-trigger"
+        onClick={onClick}
+      >
+        {configLoading ? <Loader2 size={16} className="animate-spin" /> : <Bookmark size={16} />}
+      </Button>
+    )
+  }
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      type="button"
+      className="flex items-center gap-1.5"
+      disabled={disabled || configLoading}
+      aria-label={label}
+      data-testid="environment-selector-trigger"
+      onClick={onClick}
+    >
+      {configLoading ? <Loader2 size={16} className="animate-spin" /> : <Bookmark size={16} />}
+      <span className="hidden sm:inline">{label}</span>
+    </Button>
+  )
 }
 
 export function EnvironmentProfileSelector({
@@ -78,117 +209,35 @@ export function EnvironmentProfileSelector({
     setIsDialogOpen(true)
   }
 
-  const renderTrigger = (props?: { onClick?: () => void }) => {
-    if (buttonVariant === 'input-group') {
-      return (
-        <InputGroupButton
-          type="button"
-          size="sm"
-          variant="outline"
-          grouped={false}
-          className="flex items-center gap-1.5"
-          disabled={disabled || configLoading}
-          aria-label={label}
-          data-testid="environment-selector-trigger"
-          onClick={props?.onClick}
-        >
-          {configLoading ? <Loader2 size={16} className="animate-spin" /> : <Bookmark size={16} />}
-          <span className="hidden sm:inline">{label}</span>
-        </InputGroupButton>
-      )
-    }
-
-    if (compact) {
-      return (
-        <Button
-          variant="ghost"
-          size="icon"
-          type="button"
-          className="h-9 w-9"
-          disabled={disabled || configLoading}
-          aria-label={label}
-          data-testid="environment-selector-trigger"
-          onClick={props?.onClick}
-        >
-          {configLoading ? <Loader2 size={16} className="animate-spin" /> : <Bookmark size={16} />}
-        </Button>
-      )
-    }
-
-    return (
-      <Button
-        variant="outline"
-        size="sm"
-        type="button"
-        className="flex items-center gap-1.5"
-        disabled={disabled || configLoading}
-        aria-label={label}
-        data-testid="environment-selector-trigger"
-        onClick={props?.onClick}
-      >
-        {configLoading ? <Loader2 size={16} className="animate-spin" /> : <Bookmark size={16} />}
-        <span className="hidden sm:inline">{label}</span>
-      </Button>
-    )
+  const handleDeleteProfile = (profile: EnvironmentProfile) => {
+    removeProfile(profile.id)
+    setIsOpen(false)
   }
 
-  const renderProfileSummary = (profile: EnvironmentProfile) => (
-    <div className="min-w-0 flex-1 space-y-1">
-      <div className="flex items-center gap-1 text-sm font-medium">
-        <Globe size={14} className="flex-shrink-0" />
-        <span className="truncate">{profile.name}</span>
-      </div>
-      <div className="truncate text-xs text-muted-foreground" title={profile.issuerUrl}>
-        {truncateUrl(profile.issuerUrl)}
-      </div>
-      <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
-        {profile.clientId && <span>Client: {profile.clientId}</span>}
-        {profile.scopes.length > 0 && <span>Scopes: {profile.scopes.join(' ')}</span>}
-      </div>
-      <div className="flex items-center gap-1 text-xs text-muted-foreground">
-        <Clock size={12} />
-        {formatDistanceToNow(new Date(profile.lastUsedAt), { addSuffix: true })}
-      </div>
-    </div>
-  )
+  const handleTestMenuItemKeyDown = (
+    event: React.KeyboardEvent<HTMLDivElement>,
+    profile: EnvironmentProfile
+  ) => {
+    if (event.key !== 'Enter' && event.key !== ' ') {
+      return
+    }
 
-  const renderProfileActions = (profile: EnvironmentProfile) => (
-    <div className="flex flex-shrink-0 items-center gap-1">
-      <Button
-        variant="ghost"
-        size="icon"
-        className="h-6 w-6"
-        aria-label={`Edit ${profile.name}`}
-        onClick={(event) => {
-          event.stopPropagation()
-          handleEditProfile(profile)
-        }}
-      >
-        <Edit size={14} />
-      </Button>
-      <Button
-        variant="ghost"
-        size="icon"
-        className="h-6 w-6"
-        aria-label={`Delete ${profile.name}`}
-        onClick={(event) => {
-          event.stopPropagation()
-          removeProfile(profile.id)
-          setIsOpen(false)
-        }}
-      >
-        <Trash2 size={14} />
-      </Button>
-    </div>
-  )
+    event.preventDefault()
+    handleSelectProfile(profile)
+  }
 
   return (
     <>
       {isTestEnvironment ? (
         <div className="relative">
-          {renderTrigger({
-            onClick: () => setIsOpen((currentValue) => !currentValue),
-          })}
+          <EnvironmentSelectorTrigger
+            buttonVariant={buttonVariant}
+            compact={compact}
+            configLoading={configLoading}
+            disabled={disabled}
+            label={label}
+            onClick={() => setIsOpen((currentValue) => !currentValue)}
+          />
           {isOpen && (
             <div
               role="menu"
@@ -200,12 +249,19 @@ export function EnvironmentProfileSelector({
                 <div
                   key={profile.id}
                   role="menuitem"
+                  tabIndex={0}
                   className="flex cursor-pointer items-start justify-between gap-2 rounded-sm px-2 py-1.5"
+                  aria-label={`Use ${profile.name}`}
                   onClick={() => handleSelectProfile(profile)}
+                  onKeyDown={(event) => handleTestMenuItemKeyDown(event, profile)}
                   data-testid="environment-selector-item"
                 >
-                  {renderProfileSummary(profile)}
-                  {renderProfileActions(profile)}
+                  <EnvironmentProfileSummary profile={profile} />
+                  <EnvironmentProfileActions
+                    profile={profile}
+                    onEdit={handleEditProfile}
+                    onDelete={handleDeleteProfile}
+                  />
                 </div>
               ))}
             </div>
@@ -213,7 +269,15 @@ export function EnvironmentProfileSelector({
         </div>
       ) : (
         <DropdownMenu open={isOpen} onOpenChange={setIsOpen} modal={false}>
-          <DropdownMenuTrigger asChild>{renderTrigger()}</DropdownMenuTrigger>
+          <DropdownMenuTrigger asChild>
+            <EnvironmentSelectorTrigger
+              buttonVariant={buttonVariant}
+              compact={compact}
+              configLoading={configLoading}
+              disabled={disabled}
+              label={label}
+            />
+          </DropdownMenuTrigger>
           <DropdownMenuContent align="start" className="w-[360px]">
             <DropdownMenuLabel>Saved Environments</DropdownMenuLabel>
             <DropdownMenuSeparator />
@@ -224,8 +288,12 @@ export function EnvironmentProfileSelector({
                 onClick={() => handleSelectProfile(profile)}
                 data-testid="environment-selector-item"
               >
-                {renderProfileSummary(profile)}
-                {renderProfileActions(profile)}
+                <EnvironmentProfileSummary profile={profile} />
+                <EnvironmentProfileActions
+                  profile={profile}
+                  onEdit={handleEditProfile}
+                  onDelete={handleDeleteProfile}
+                />
               </DropdownMenuItem>
             ))}
           </DropdownMenuContent>

--- a/src/components/common/IssuerHistory.tsx
+++ b/src/components/common/IssuerHistory.tsx
@@ -174,17 +174,25 @@ export function IssuerHistory({
                     onChange={(e) => setEditName(e.target.value)}
                     className="flex-1 px-2 py-1 text-sm border rounded"
                     placeholder="Issuer name"
+                    aria-label={`Name for ${issuer.url}`}
                   />
                   <div className="flex gap-1">
                     <Button
                       variant="ghost"
                       size="icon"
                       className="h-6 w-6"
+                      aria-label={`Save name for ${issuer.url}`}
                       onClick={() => saveEdit(issuer.id)}
                     >
                       <Check size={14} />
                     </Button>
-                    <Button variant="ghost" size="icon" className="h-6 w-6" onClick={cancelEdit}>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6"
+                      aria-label="Cancel editing issuer name"
+                      onClick={cancelEdit}
+                    >
                       <Trash2 size={14} />
                     </Button>
                   </div>
@@ -221,6 +229,7 @@ export function IssuerHistory({
                       variant="ghost"
                       size="icon"
                       className="h-6 w-6"
+                      aria-label={`Rename ${issuer.name || issuer.url}`}
                       onClick={(e) => {
                         e.stopPropagation()
                         startEditing(issuer.id, issuer.name)
@@ -232,6 +241,7 @@ export function IssuerHistory({
                       variant="ghost"
                       size="icon"
                       className="h-6 w-6"
+                      aria-label={`Delete ${issuer.name || issuer.url}`}
                       onClick={(e) => {
                         e.stopPropagation()
                         removeIssuer(issuer.id)

--- a/src/components/common/TokenHistoryDropdown.tsx
+++ b/src/components/common/TokenHistoryDropdown.tsx
@@ -120,17 +120,25 @@ export function TokenHistoryDropdown({
                   onChange={(e) => setEditName(e.target.value)}
                   className="flex-1 px-2 py-1 text-sm border rounded"
                   placeholder="Token name"
+                  aria-label="Token history name"
                 />
                 <div className="flex gap-1">
                   <Button
                     variant="ghost"
                     size="icon"
                     className="h-6 w-6"
+                    aria-label="Save token name"
                     onClick={() => saveEdit(token.id)}
                   >
                     <Check size={14} />
                   </Button>
-                  <Button variant="ghost" size="icon" className="h-6 w-6" onClick={cancelEdit}>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6"
+                    aria-label="Cancel editing token name"
+                    onClick={cancelEdit}
+                  >
                     <Trash2 size={14} />
                   </Button>
                 </div>
@@ -225,6 +233,7 @@ export function TokenHistoryDropdown({
                     variant="ghost"
                     size="icon"
                     className="h-6 w-6"
+                    aria-label={`Rename ${token.name || truncateToken(token.token)}`}
                     onClick={(e) => {
                       e.stopPropagation()
                       startEditing(token.id, token.name)
@@ -236,6 +245,7 @@ export function TokenHistoryDropdown({
                     variant="ghost"
                     size="icon"
                     className="h-6 w-6"
+                    aria-label={`Delete ${token.name || truncateToken(token.token)}`}
                     onClick={(e) => {
                       e.stopPropagation()
                       removeToken(token.id)

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -31,16 +31,21 @@ const buttonVariants = cva(
 )
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
   asChild?: boolean
 }
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : 'button'
+    const buttonProps = asChild ? props : { type: 'button' as const, ...props }
+
     return (
-      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...buttonProps}
+      />
     )
   }
 )

--- a/src/components/ui/field.tsx
+++ b/src/components/ui/field.tsx
@@ -27,8 +27,10 @@ export interface FieldProps extends React.HTMLAttributes<HTMLDivElement> {
 
 export const Field = React.forwardRef<HTMLDivElement, FieldProps>(
   ({ className, orientation = 'vertical', ...props }, ref) => {
+    const contextValue = React.useMemo(() => ({ orientation }), [orientation])
+
     return (
-      <FieldContext.Provider value={{ orientation }}>
+      <FieldContext.Provider value={contextValue}>
         <div
           ref={ref}
           data-orientation={orientation}

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -33,8 +33,10 @@ const FormField = <
 >({
   ...props
 }: ControllerProps<TFieldValues, TName>) => {
+  const contextValue = React.useMemo(() => ({ name: props.name }), [props.name])
+
   return (
-    <FormFieldContext.Provider value={{ name: props.name }}>
+    <FormFieldContext.Provider value={contextValue}>
       <Controller {...props} />
     </FormFieldContext.Provider>
   )
@@ -71,9 +73,10 @@ const FormItemContext = React.createContext<FormItemContextValue>({} as FormItem
 
 function FormItem({ className, ...props }: React.ComponentProps<'div'>) {
   const id = React.useId()
+  const contextValue = React.useMemo(() => ({ id }), [id])
 
   return (
-    <FormItemContext.Provider value={{ id }}>
+    <FormItemContext.Provider value={contextValue}>
       <div data-slot="form-item" className={cn('grid gap-2', className)} {...props} />
     </FormItemContext.Provider>
   )

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -270,6 +270,7 @@ function SidebarRail({ className, ...props }: React.ComponentProps<'button'>) {
 
   return (
     <button
+      type="button"
       data-sidebar="rail"
       data-slot="sidebar-rail"
       aria-label="Toggle Sidebar"

--- a/src/features/home/index.tsx
+++ b/src/features/home/index.tsx
@@ -1,302 +1,240 @@
 import { Link } from 'react-router-dom'
-import { PageContainer, PageHeader } from '@/components/page'
 import {
-  HomeIcon,
-  Search,
-  FileJson,
-  KeyRound,
-  Shield,
-  FileSearch,
-  Hammer,
   BadgeCheck,
-  FileCog,
   Database,
-  FileText,
+  FileCog,
+  FileJson,
   FilePlus2,
+  FileSearch,
+  FileText,
+  Hammer,
+  HomeIcon,
+  KeyRound,
+  Search,
+  Shield,
 } from 'lucide-react'
-import { Item, ItemContent, ItemDescription, ItemGroup, ItemMedia } from '@/components/ui/item'
+import type { LucideIcon } from 'lucide-react'
+import { PageContainer, PageHeader } from '@/components/page'
+import { Badge } from '@/components/ui/badge'
+import {
+  Item,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemMedia,
+  ItemTitle,
+} from '@/components/ui/item'
+
+interface ToolDefinition {
+  title: string
+  description: string
+  to: string
+  icon: LucideIcon
+  testId: string
+  tags: string[]
+}
+
+interface ToolSection {
+  title: string
+  description: string
+  icon: LucideIcon
+  tools: ToolDefinition[]
+}
+
+const toolSections: ToolSection[] = [
+  {
+    title: 'OAuth/OIDC',
+    description: 'Inspect tokens, discovery metadata, JWKS, and common OAuth flows.',
+    icon: KeyRound,
+    tools: [
+      {
+        title: 'Token Inspector',
+        description: 'Decode JWTs, validate signatures, inspect claims, and load saved issuers.',
+        to: '/token-inspector',
+        icon: Search,
+        testId: 'home-card-token-inspector',
+        tags: ['JWT', 'JWKS'],
+      },
+      {
+        title: 'OIDC Explorer',
+        description: 'Fetch discovery documents, inspect provider metadata, and review keys.',
+        to: '/oidc-explorer',
+        icon: FileJson,
+        testId: 'home-card-oidc-explorer',
+        tags: ['Discovery', 'Keys'],
+      },
+      {
+        title: 'OAuth Playground',
+        description:
+          'Exercise auth code with PKCE, client credentials, introspection, and UserInfo.',
+        to: '/oauth-playground',
+        icon: KeyRound,
+        testId: 'home-card-oauth-playground',
+        tags: ['Flows', 'Demo IdP'],
+      },
+    ],
+  },
+  {
+    title: 'SAML',
+    description: 'Decode responses, build AuthnRequests, and work with service-provider metadata.',
+    icon: Shield,
+    tools: [
+      {
+        title: 'Response Decoder',
+        description: 'Decode SAML responses and inspect assertions, attributes, and status codes.',
+        to: '/saml/response-decoder',
+        icon: FileSearch,
+        testId: 'home-card-saml-response-decoder',
+        tags: ['Response', 'Assertions'],
+      },
+      {
+        title: 'AuthnRequest Builder',
+        description: 'Craft HTTP-POST and HTTP-Redirect AuthnRequests with optional signing.',
+        to: '/saml/request-builder',
+        icon: Hammer,
+        testId: 'home-card-saml-request-builder',
+        tags: ['Request', 'Redirect'],
+      },
+      {
+        title: 'Metadata Validator',
+        description: 'Fetch or paste metadata XML, review roles, endpoints, and signatures.',
+        to: '/saml/metadata-validator',
+        icon: BadgeCheck,
+        testId: 'home-card-saml-metadata-validator',
+        tags: ['Metadata', 'Signatures'],
+      },
+      {
+        title: 'SP Metadata Generator',
+        description: 'Generate SP metadata with ACS/SLO endpoints, NameID formats, and certs.',
+        to: '/saml/sp-metadata',
+        icon: FileCog,
+        testId: 'home-card-saml-sp-metadata',
+        tags: ['SP', 'XML'],
+      },
+    ],
+  },
+  {
+    title: 'LDAP',
+    description: 'Parse directory schemas and validate LDIF entries locally in the browser.',
+    icon: Database,
+    tools: [
+      {
+        title: 'Schema Explorer',
+        description: 'Paste attributeTypes/objectClasses LDIF and save schema snapshots.',
+        to: '/ldap/schema-explorer',
+        icon: FileText,
+        testId: 'home-card-ldap-schema-explorer',
+        tags: ['Schema', 'Offline'],
+      },
+      {
+        title: 'LDIF Builder & Viewer',
+        description: 'Import or compose LDIF, apply templates, and validate entries.',
+        to: '/ldap/ldif-builder',
+        icon: FilePlus2,
+        testId: 'home-card-ldap-ldif-builder',
+        tags: ['LDIF', 'Validation'],
+      },
+    ],
+  },
+]
+
+const featuredTools = [toolSections[0].tools[0], toolSections[0].tools[1], toolSections[2].tools[1]]
+
+const totalToolCount = toolSections.reduce((count, section) => count + section.tools.length, 0)
+
+function ToolCard({ tool, exposeTestId = true }: { tool: ToolDefinition; exposeTestId?: boolean }) {
+  const Icon = tool.icon
+
+  return (
+    <Item asChild interactive className="h-full p-0">
+      <Link
+        to={tool.to}
+        className="flex h-full w-full items-start gap-4 p-4"
+        data-testid={exposeTestId ? tool.testId : undefined}
+      >
+        <ItemMedia variant="icon" className="bg-primary/10 text-primary">
+          <Icon className="h-5 w-5" aria-hidden="true" />
+        </ItemMedia>
+        <ItemContent className="min-w-0 gap-3">
+          <div className="flex min-w-0 flex-col gap-1">
+            <ItemTitle>{tool.title}</ItemTitle>
+            <ItemDescription>{tool.description}</ItemDescription>
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {tool.tags.map((tag) => (
+              <Badge key={tag} variant="secondary" className="text-[10px]">
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        </ItemContent>
+      </Link>
+    </Item>
+  )
+}
+
+function SectionHeader({ section }: { section: ToolSection }) {
+  const Icon = section.icon
+
+  return (
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+      <div className="flex items-start gap-3">
+        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+          <Icon className="h-5 w-5" aria-hidden="true" />
+        </span>
+        <div className="min-w-0">
+          <h2 className="text-xl font-semibold tracking-normal">{section.title}</h2>
+          <p className="text-sm text-muted-foreground">{section.description}</p>
+        </div>
+      </div>
+      <Badge variant="outline" className="w-fit">
+        {section.tools.length} tool{section.tools.length === 1 ? '' : 's'}
+      </Badge>
+    </div>
+  )
+}
 
 export default function HomePage() {
   return (
     <PageContainer>
       <PageHeader
-        title="Welcome to IAM Tools"
-        description="A collection of specialized tools for Identity and Access Management (IAM) development and debugging."
+        title="IAM Tools"
+        description="A focused workbench for Identity and Access Management development, debugging, and protocol inspection."
         icon={HomeIcon}
       />
 
-      <div className="space-y-10">
-        <section className="space-y-8">
-          <h2 className="text-2xl font-semibold flex items-center gap-2">
-            <KeyRound className="h-6 w-6" />
-            OAuth/OIDC Tools
-          </h2>
-          <ItemGroup className="grid grid-cols-1 gap-4">
-            <Item
-              asChild
-              interactive
-              className="h-full border border-blue-100 bg-white text-slate-900 shadow-sm transition-colors hover:bg-blue-50/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:border-blue-500/30 dark:bg-card/80 dark:text-white dark:hover:bg-card/90 dark:focus-visible:ring-white/60"
-            >
-              <Link
-                to="/token-inspector"
-                className="flex h-full w-full items-center gap-4 p-6"
-                data-testid="home-card-token-inspector"
-              >
-                <ItemMedia
-                  variant="icon"
-                  className="bg-blue-500/10 text-blue-600 dark:bg-white/20 dark:text-white"
-                >
-                  <Search className="h-6 w-6" />
-                </ItemMedia>
-                <ItemContent>
-                  <h3 className="text-xl font-semibold leading-tight text-slate-900 dark:text-white">
-                    Token Inspector
-                  </h3>
-                  <ItemDescription className="text-muted-foreground dark:text-white/80">
-                    Analyze JWT tokens, validate signatures, and inspect claims.
-                  </ItemDescription>
-                </ItemContent>
-              </Link>
-            </Item>
+      <div className="flex flex-col gap-8">
+        <section className="grid gap-3 lg:grid-cols-4">
+          <Item className="h-full">
+            <ItemMedia variant="icon" className="bg-primary text-primary-foreground">
+              <KeyRound className="h-5 w-5" aria-hidden="true" />
+            </ItemMedia>
+            <ItemContent>
+              <ItemTitle>{totalToolCount} local-first tools</ItemTitle>
+              <ItemDescription>
+                Most workflows run in the browser, with proxy support only where identity endpoints
+                need it.
+              </ItemDescription>
+            </ItemContent>
+          </Item>
 
-            <Item
-              asChild
-              interactive
-              className="h-full border border-indigo-100 bg-white text-slate-900 shadow-sm transition-colors hover:bg-indigo-50/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-indigo-500/30 dark:bg-card/80 dark:text-white dark:hover:bg-card/90 dark:focus-visible:ring-white/60"
-            >
-              <Link
-                to="/oidc-explorer"
-                className="flex h-full w-full items-center gap-4 p-6"
-                data-testid="home-card-oidc-explorer"
-              >
-                <ItemMedia
-                  variant="icon"
-                  className="bg-indigo-500/10 text-indigo-600 dark:bg-white/20 dark:text-white"
-                >
-                  <FileJson className="h-6 w-6" />
-                </ItemMedia>
-                <ItemContent>
-                  <h3 className="text-xl font-semibold leading-tight text-slate-900 dark:text-white">
-                    OIDC Explorer
-                  </h3>
-                  <ItemDescription className="text-muted-foreground dark:text-white/80">
-                    Explore OpenID Connect discovery documents and JWKS endpoints quickly.
-                  </ItemDescription>
-                </ItemContent>
-              </Link>
-            </Item>
-
-            <Item
-              asChild
-              interactive
-              className="h-full border border-emerald-100 bg-white text-slate-900 shadow-sm transition-colors hover:bg-emerald-50/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 dark:border-emerald-500/30 dark:bg-card/80 dark:text-white dark:hover:bg-card/90 dark:focus-visible:ring-white/60"
-            >
-              <Link
-                to="/oauth-playground"
-                className="flex h-full w-full items-center gap-4 p-6"
-                data-testid="home-card-oauth-playground"
-              >
-                <ItemMedia
-                  variant="icon"
-                  className="bg-emerald-500/10 text-emerald-600 dark:bg-white/20 dark:text-white"
-                >
-                  <KeyRound className="h-6 w-6" />
-                </ItemMedia>
-                <ItemContent>
-                  <h3 className="text-xl font-semibold leading-tight text-slate-900 dark:text-white">
-                    OAuth Playground
-                  </h3>
-                  <ItemDescription className="text-muted-foreground dark:text-white/80">
-                    Test and explore OAuth 2.0 flows with step-by-step guidance.
-                  </ItemDescription>
-                </ItemContent>
-              </Link>
-            </Item>
+          <ItemGroup className="grid gap-3 sm:grid-cols-3 lg:col-span-3">
+            {featuredTools.map((tool) => (
+              <ToolCard key={tool.to} tool={tool} exposeTestId={false} />
+            ))}
           </ItemGroup>
         </section>
 
-        <section className="grid auto-rows-min gap-6 md:grid-cols-2">
-          <div className="space-y-8">
-            <h2 className="text-2xl font-semibold flex items-center gap-2">
-              <Shield className="h-6 w-6" />
-              SAML Tools
-            </h2>
-            <ItemGroup className="grid grid-cols-1 gap-4">
-              <Item
-                asChild
-                interactive
-                className="h-full border border-purple-100 bg-white text-slate-900 shadow-sm transition-colors hover:bg-purple-50/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 focus-visible:ring-offset-2 dark:border-purple-500/30 dark:bg-card/80 dark:text-white dark:hover:bg-card/90 dark:focus-visible:ring-white/60"
-              >
-                <Link
-                  to="/saml/response-decoder"
-                  className="flex h-full w-full items-center gap-4 p-6"
-                  data-testid="home-card-saml-response-decoder"
-                >
-                  <ItemMedia
-                    variant="icon"
-                    className="bg-purple-500/10 text-purple-600 dark:bg-white/20 dark:text-white"
-                  >
-                    <FileSearch className="h-6 w-6" />
-                  </ItemMedia>
-                  <ItemContent>
-                    <h3 className="text-xl font-semibold leading-tight text-slate-900 dark:text-white">
-                      Response Decoder
-                    </h3>
-                    <ItemDescription className="text-muted-foreground dark:text-white/80">
-                      Decode and inspect SAML Responses, assertions, and attributes quickly.
-                    </ItemDescription>
-                  </ItemContent>
-                </Link>
-              </Item>
-
-              <Item
-                asChild
-                interactive
-                className="h-full border border-amber-100 bg-white text-slate-900 shadow-sm transition-colors hover:bg-amber-50/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 dark:border-amber-500/30 dark:bg-card/80 dark:text-white dark:hover:bg-card/90 dark:focus-visible:ring-white/60"
-              >
-                <Link
-                  to="/saml/request-builder"
-                  className="flex h-full w-full items-center gap-4 p-6"
-                  data-testid="home-card-saml-request-builder"
-                >
-                  <ItemMedia
-                    variant="icon"
-                    className="bg-amber-500/10 text-amber-600 dark:bg-white/20 dark:text-white"
-                  >
-                    <Hammer className="h-6 w-6" />
-                  </ItemMedia>
-                  <ItemContent>
-                    <h3 className="text-xl font-semibold leading-tight text-slate-900 dark:text-white">
-                      AuthnRequest Builder
-                    </h3>
-                    <ItemDescription className="text-muted-foreground dark:text-white/80">
-                      Craft HTTP-POST and HTTP-Redirect AuthnRequests with optional redirect
-                      signing.
-                    </ItemDescription>
-                  </ItemContent>
-                </Link>
-              </Item>
-
-              <Item
-                asChild
-                interactive
-                className="h-full border border-emerald-100 bg-white text-slate-900 shadow-sm transition-colors hover:bg-emerald-50/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 dark:border-emerald-500/30 dark:bg-card/80 dark:text-white dark:hover:bg-card/90 dark:focus-visible:ring-white/60"
-              >
-                <Link
-                  to="/saml/metadata-validator"
-                  className="flex h-full w-full items-center gap-4 p-6"
-                  data-testid="home-card-saml-metadata-validator"
-                >
-                  <ItemMedia
-                    variant="icon"
-                    className="bg-emerald-500/10 text-emerald-600 dark:bg-white/20 dark:text-white"
-                  >
-                    <BadgeCheck className="h-6 w-6" />
-                  </ItemMedia>
-                  <ItemContent>
-                    <h3 className="text-xl font-semibold leading-tight text-slate-900 dark:text-white">
-                      Metadata Validator
-                    </h3>
-                    <ItemDescription className="text-muted-foreground dark:text-white/80">
-                      Fetch or paste metadata XML, view roles and endpoints, and verify signatures.
-                    </ItemDescription>
-                  </ItemContent>
-                </Link>
-              </Item>
-
-              <Item
-                asChild
-                interactive
-                className="h-full border border-sky-100 bg-white text-slate-900 shadow-sm transition-colors hover:bg-sky-50/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:border-sky-500/30 dark:bg-card/80 dark:text-white dark:hover:bg-card/90 dark:focus-visible:ring-white/60"
-              >
-                <Link
-                  to="/saml/sp-metadata"
-                  className="flex h-full w-full items-center gap-4 p-6"
-                  data-testid="home-card-saml-sp-metadata"
-                >
-                  <ItemMedia
-                    variant="icon"
-                    className="bg-sky-500/10 text-sky-600 dark:bg-white/20 dark:text-white"
-                  >
-                    <FileCog className="h-6 w-6" />
-                  </ItemMedia>
-                  <ItemContent>
-                    <h3 className="text-xl font-semibold leading-tight text-slate-900 dark:text-white">
-                      SP Metadata Generator
-                    </h3>
-                    <ItemDescription className="text-muted-foreground dark:text-white/80">
-                      Generate SP metadata with ACS/SLO endpoints, NameID formats, and certs.
-                    </ItemDescription>
-                  </ItemContent>
-                </Link>
-              </Item>
+        {toolSections.map((section) => (
+          <section key={section.title} className="flex flex-col gap-4">
+            <SectionHeader section={section} />
+            <ItemGroup className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+              {section.tools.map((tool) => (
+                <ToolCard key={tool.to} tool={tool} />
+              ))}
             </ItemGroup>
-          </div>
-
-          <div className="space-y-8">
-            <h2 className="text-2xl font-semibold flex items-center gap-2">
-              <Database className="h-6 w-6" />
-              LDAP Tools
-            </h2>
-            <ItemGroup className="grid grid-cols-1 gap-4">
-              <Item
-                asChild
-                interactive
-                className="h-full border border-teal-100 bg-white text-slate-900 shadow-sm transition-colors hover:bg-teal-50/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-2 dark:border-teal-500/30 dark:bg-card/80 dark:text-white dark:hover:bg-card/90 dark:focus-visible:ring-white/60"
-              >
-                <Link
-                  to="/ldap/schema-explorer"
-                  className="flex h-full w-full items-center gap-4 p-6"
-                  data-testid="home-card-ldap-schema-explorer"
-                >
-                  <ItemMedia
-                    variant="icon"
-                    className="bg-teal-500/10 text-teal-600 dark:bg-white/20 dark:text-white"
-                  >
-                    <FileText className="h-6 w-6" />
-                  </ItemMedia>
-                  <ItemContent>
-                    <h3 className="text-xl font-semibold leading-tight text-slate-900 dark:text-white">
-                      Schema Explorer
-                    </h3>
-                    <ItemDescription className="text-muted-foreground dark:text-white/80">
-                      Paste attributeTypes/objectClasses LDIF to visualize schema structures
-                      offline.
-                    </ItemDescription>
-                  </ItemContent>
-                </Link>
-              </Item>
-
-              <Item
-                asChild
-                interactive
-                className="h-full border border-rose-100 bg-white text-slate-900 shadow-sm transition-colors hover:bg-rose-50/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-2 dark:border-rose-500/30 dark:bg-card/80 dark:text-white dark:hover:bg-card/90 dark:focus-visible:ring-white/60"
-              >
-                <Link
-                  to="/ldap/ldif-builder"
-                  className="flex h-full w-full items-center gap-4 p-6"
-                  data-testid="home-card-ldap-ldif-builder"
-                >
-                  <ItemMedia
-                    variant="icon"
-                    className="bg-rose-500/10 text-rose-600 dark:bg-white/20 dark:text-white"
-                  >
-                    <FilePlus2 className="h-6 w-6" />
-                  </ItemMedia>
-                  <ItemContent>
-                    <h3 className="text-xl font-semibold leading-tight text-slate-900 dark:text-white">
-                      LDIF Builder &amp; Viewer
-                    </h3>
-                    <ItemDescription className="text-muted-foreground dark:text-white/80">
-                      Import or compose LDIF, apply templates, and validate against saved schema
-                      snapshots.
-                    </ItemDescription>
-                  </ItemContent>
-                </Link>
-              </Item>
-            </ItemGroup>
-          </div>
-        </section>
+          </section>
+        ))}
       </div>
     </PageContainer>
   )

--- a/src/features/ldap/pages/ldif-builder/index.tsx
+++ b/src/features/ldap/pages/ldif-builder/index.tsx
@@ -175,6 +175,7 @@ export default function LdifBuilderPage() {
         accept=".ldif,.txt,.ldf,text/plain"
         onChange={handleFileSelected}
         className="hidden"
+        aria-label="Upload LDIF file"
       />
 
       <div className="space-y-10">

--- a/src/features/ldap/pages/schema-explorer/index.tsx
+++ b/src/features/ldap/pages/schema-explorer/index.tsx
@@ -131,7 +131,7 @@ function highlightSchemaLine(line: string): React.ReactNode {
 
 function buildInheritanceChain(
   objectClass: ParsedObjectClass,
-  allClasses: ParsedObjectClass[],
+  objectClassByName: Map<string, ParsedObjectClass>,
   visited = new Set<string>()
 ): string[] {
   const chain: string[] = []
@@ -143,11 +143,9 @@ function buildInheritanceChain(
   if (objectClass.superior && objectClass.superior.length > 0) {
     for (const sup of objectClass.superior) {
       chain.push(sup)
-      const parent = allClasses.find((oc) =>
-        oc.names.some((n) => n.toLowerCase() === sup.toLowerCase())
-      )
+      const parent = objectClassByName.get(sup.toLowerCase())
       if (parent) {
-        chain.push(...buildInheritanceChain(parent, allClasses, visited))
+        chain.push(...buildInheritanceChain(parent, objectClassByName, visited))
       }
     }
   }
@@ -167,6 +165,17 @@ export default function LdapSchemaExplorerPage() {
   const { schemas, upsertSchema, removeSchema } = useSavedSchemas()
 
   const parsed = useMemo(() => parseLdapSchema(schemaText), [schemaText])
+  const objectClassByName = useMemo(() => {
+    const map = new Map<string, ParsedObjectClass>()
+
+    for (const objectClass of parsed.objectClasses) {
+      for (const name of objectClass.names) {
+        map.set(name.toLowerCase(), objectClass)
+      }
+    }
+
+    return map
+  }, [parsed.objectClasses])
   const hasInput = schemaText.trim().length > 0
 
   // Filter object classes and attributes based on search
@@ -327,6 +336,7 @@ export default function LdapSchemaExplorerPage() {
         accept=".schema,.ldif,.txt,.ldf,text/plain"
         onChange={handleFileSelected}
         className="hidden"
+        aria-label="Upload schema file"
       />
 
       <div className="space-y-10">
@@ -597,6 +607,7 @@ export default function LdapSchemaExplorerPage() {
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 className="pl-10"
+                aria-label="Search schema definitions"
               />
             </div>
           </>
@@ -633,7 +644,7 @@ export default function LdapSchemaExplorerPage() {
           ) : (
             <div className="grid gap-4 lg:grid-cols-2">
               {filteredObjectClasses.map((objectClass) => {
-                const inheritanceChain = buildInheritanceChain(objectClass, parsed.objectClasses)
+                const inheritanceChain = buildInheritanceChain(objectClass, objectClassByName)
                 return (
                   <Card key={`${objectClass.oid}-${objectClass.names[0] ?? 'unnamed'}`}>
                     <CardHeader>

--- a/src/features/oauthPlayground/components/AuthCodeWithPkceFlow.tsx
+++ b/src/features/oauthPlayground/components/AuthCodeWithPkceFlow.tsx
@@ -29,6 +29,7 @@ const clearRedirectState = () => {
 
 export function AuthCodeWithPkceFlow() {
   const location = useLocation()
+  const callbackCode = typeof location.state?.code === 'string' ? location.state.code : null
   const [flowState, setFlowState] = useState<{
     activeTab: string
     config: OAuthConfig | null
@@ -43,23 +44,23 @@ export function AuthCodeWithPkceFlow() {
 
   // Initialize from location state (returning from callback)
   useEffect(() => {
-    if (!location.state?.code) return
+    if (!callbackCode) return
 
     const redirectState = readRedirectState()
     setFlowState((currentState) => {
       if (!redirectState) {
-        return { ...currentState, authCode: location.state.code }
+        return { ...currentState, authCode: callbackCode }
       }
 
       clearRedirectState()
       return {
         activeTab: 'token',
-        authCode: location.state.code,
+        authCode: callbackCode,
         config: redirectState.config,
         pkce: redirectState.pkce,
       }
     })
-  }, [location.state])
+  }, [callbackCode])
 
   // Handle configuration completion
   const handleConfigComplete = (newConfig: OAuthConfig, newPkce: PkceParams) => {

--- a/src/features/oauthPlayground/components/AuthorizationRequest.tsx
+++ b/src/features/oauthPlayground/components/AuthorizationRequest.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import {
   Card,
   CardContent,
@@ -35,37 +35,12 @@ export function AuthorizationRequest({
   pkce,
   onAuthorizationComplete,
 }: AuthorizationRequestProps) {
-  const [authUrl, setAuthUrl] = useState<string>('')
-  const [authWindow, setAuthWindow] = useState<Window | null>(null)
+  const authWindowRef = useRef<Window | null>(null)
 
-  // Listen for messages from the popup window
-  useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      // Make sure the message is from our domain
-      if (event.origin !== window.location.origin) return
-
-      // Check if it's our OAuth callback message
-      if (event.data?.type === 'oauth_callback' && event.data?.code) {
-        sessionStorage.removeItem(OAUTH_PLAYGROUND_REDIRECT_STATE_KEY)
-        onAuthorizationComplete(event.data.code)
-
-        // Close the popup if it's still open
-        if (authWindow && !authWindow.closed) {
-          authWindow.close()
-        }
-      }
-    }
-
-    window.addEventListener('message', handleMessage)
-    return () => window.removeEventListener('message', handleMessage)
-  }, [authWindow, onAuthorizationComplete])
-
-  // Build the authorization URL
-  useEffect(() => {
+  const authUrl = useMemo(() => {
     const baseUrl = config.authEndpoint
     if (!baseUrl) {
-      setAuthUrl('')
-      return
+      return ''
     }
 
     const params = new URLSearchParams({
@@ -81,18 +56,14 @@ export function AuthorizationRequest({
       params.set('scope', config.scopes.join(' '))
     }
 
-    const constructedUrl = `${baseUrl}?${params.toString()}`
-    let nextAuthUrl = ''
-
     try {
-      nextAuthUrl = new URL(constructedUrl).toString()
+      return new URL(`${baseUrl}?${params.toString()}`).toString()
     } catch (error) {
       if (import.meta?.env?.DEV) {
         console.error('Invalid authorization URL:', error)
       }
+      return ''
     }
-
-    setAuthUrl(nextAuthUrl)
   }, [
     config.authEndpoint,
     config.clientId,
@@ -101,6 +72,30 @@ export function AuthorizationRequest({
     pkce.codeChallenge,
     pkce.state,
   ])
+
+  // Listen for messages from the popup window
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      // Make sure the message is from our domain
+      if (event.origin !== window.location.origin) return
+
+      // Check if it's our OAuth callback message
+      if (event.data?.type === 'oauth_callback' && event.data?.code) {
+        sessionStorage.removeItem(OAUTH_PLAYGROUND_REDIRECT_STATE_KEY)
+        onAuthorizationComplete(event.data.code)
+
+        // Close the popup if it's still open
+        const authWindow = authWindowRef.current
+        if (authWindow && !authWindow.closed) {
+          authWindow.close()
+          authWindowRef.current = null
+        }
+      }
+    }
+
+    window.addEventListener('message', handleMessage)
+    return () => window.removeEventListener('message', handleMessage)
+  }, [onAuthorizationComplete])
 
   const storeRedirectState = () => {
     if (typeof window === 'undefined') return
@@ -133,7 +128,7 @@ export function AuthorizationRequest({
     const features = `width=${width},height=${height},left=${left},top=${top}`
 
     const popupWindow = window.open(authUrl, 'oauth-authorization', features)
-    setAuthWindow(popupWindow)
+    authWindowRef.current = popupWindow
 
     // Check if popup was blocked
     if (!popupWindow || popupWindow.closed || typeof popupWindow.closed === 'undefined') {

--- a/src/features/oauthPlayground/components/TokenExchange.tsx
+++ b/src/features/oauthPlayground/components/TokenExchange.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
   Card,
@@ -24,6 +24,57 @@ interface TokenExchangeProps {
   onTokenExchangeComplete?: (tokenResponse: TokenResponse) => void
 }
 
+function appendSharedTokenPayloadParams(
+  payload: URLSearchParams,
+  config: OAuthConfig,
+  claimsValue?: string
+) {
+  if (config.clientSecret) {
+    payload.append('client_secret', config.clientSecret)
+  }
+
+  if (config.scopes?.length) {
+    payload.append('scope', config.scopes.join(' '))
+  }
+
+  if (claimsValue) {
+    payload.append('claims', claimsValue)
+  }
+}
+
+function createAuthorizationCodeTokenPayload(
+  config: OAuthConfig,
+  pkce: PkceParams,
+  authorizationCode: string,
+  claimsValue?: string
+) {
+  const payload = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code: authorizationCode,
+    redirect_uri: config.redirectUri,
+    client_id: config.clientId,
+    code_verifier: pkce.codeVerifier,
+  })
+
+  appendSharedTokenPayloadParams(payload, config, claimsValue)
+  return payload
+}
+
+function createRefreshTokenPayload(
+  config: OAuthConfig,
+  refreshToken: string,
+  claimsValue?: string
+) {
+  const payload = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+    client_id: config.clientId,
+  })
+
+  appendSharedTokenPayloadParams(payload, config, claimsValue)
+  return payload
+}
+
 export function TokenExchange({
   config,
   pkce,
@@ -34,78 +85,20 @@ export function TokenExchange({
   const [isExchanging, setIsExchanging] = useState<boolean>(false)
   const [isRefreshing, setIsRefreshing] = useState<boolean>(false)
   const [tokenResponse, setTokenResponse] = useState<TokenResponse | null>(null)
-  const [tokenRequestPayload, setTokenRequestPayload] = useState<string>('')
   const [customClaims, setCustomClaims] = useState<string>('')
   const [customClaimsError, setCustomClaimsError] = useState<string | null>(null)
   const [refreshToken, setRefreshToken] = useState<string>('')
   const [refreshResponse, setRefreshResponse] = useState<TokenResponse | null>(null)
-  const [refreshRequestPayload, setRefreshRequestPayload] = useState<string>('')
-
-  // Create token request payload
-  useEffect(() => {
-    const payload = new URLSearchParams({
-      grant_type: 'authorization_code',
-      code: authorizationCode,
-      redirect_uri: config.redirectUri,
-      client_id: config.clientId,
-      code_verifier: pkce.codeVerifier,
-    })
-
-    if (config.clientSecret) {
-      payload.append('client_secret', config.clientSecret)
-    }
-
-    if (config.scopes?.length) {
-      payload.append('scope', config.scopes.join(' '))
-    }
-
-    if (customClaims.trim()) {
-      payload.append('claims', customClaims.trim())
-    }
-
-    setTokenRequestPayload(payload.toString())
-  }, [
+  const customClaimsValue = customClaims.trim()
+  const tokenRequestPayload = createAuthorizationCodeTokenPayload(
+    config,
+    pkce,
     authorizationCode,
-    config.clientId,
-    config.clientSecret,
-    config.redirectUri,
-    config.scopes,
-    customClaims,
-    pkce.codeVerifier,
-  ])
-
-  useEffect(() => {
-    if (tokenResponse?.refresh_token) {
-      setRefreshToken(tokenResponse.refresh_token)
-    }
-  }, [tokenResponse?.refresh_token])
-
-  useEffect(() => {
-    if (!refreshToken) {
-      setRefreshRequestPayload('')
-      return
-    }
-
-    const payload = new URLSearchParams({
-      grant_type: 'refresh_token',
-      refresh_token: refreshToken,
-      client_id: config.clientId,
-    })
-
-    if (config.clientSecret) {
-      payload.append('client_secret', config.clientSecret)
-    }
-
-    if (config.scopes?.length) {
-      payload.append('scope', config.scopes.join(' '))
-    }
-
-    if (customClaims.trim()) {
-      payload.append('claims', customClaims.trim())
-    }
-
-    setRefreshRequestPayload(payload.toString())
-  }, [refreshToken, config.clientId, config.clientSecret, config.scopes, customClaims])
+    customClaimsValue
+  ).toString()
+  const refreshRequestPayload = refreshToken
+    ? createRefreshTokenPayload(config, refreshToken, customClaimsValue).toString()
+    : ''
 
   const validateClaims = () => {
     if (!customClaims.trim()) {
@@ -144,25 +137,12 @@ export function TokenExchange({
         return
       }
 
-      const payload = new URLSearchParams({
-        grant_type: 'authorization_code',
-        code: authorizationCode,
-        redirect_uri: config.redirectUri,
-        client_id: config.clientId,
-        code_verifier: pkce.codeVerifier,
-      })
-
-      if (config.clientSecret) {
-        payload.append('client_secret', config.clientSecret)
-      }
-
-      if (config.scopes?.length) {
-        payload.append('scope', config.scopes.join(' '))
-      }
-
-      if (claimsValue) {
-        payload.append('claims', claimsValue)
-      }
+      const payload = createAuthorizationCodeTokenPayload(
+        config,
+        pkce,
+        authorizationCode,
+        claimsValue || undefined
+      )
 
       const response = await proxyFetch(tokenEndpoint, {
         method: 'POST',
@@ -188,6 +168,7 @@ export function TokenExchange({
       }
 
       setTokenResponse(tokenData)
+      setRefreshToken(tokenData.refresh_token ?? '')
       onTokenExchangeComplete?.(tokenData)
 
       toast.success(`Successfully refreshed tokens${config.demoMode ? ' (demo mode)' : ''}`)
@@ -220,23 +201,7 @@ export function TokenExchange({
         return
       }
 
-      const payload = new URLSearchParams({
-        grant_type: 'refresh_token',
-        refresh_token: refreshToken,
-        client_id: config.clientId,
-      })
-
-      if (config.clientSecret) {
-        payload.append('client_secret', config.clientSecret)
-      }
-
-      if (config.scopes?.length) {
-        payload.append('scope', config.scopes.join(' '))
-      }
-
-      if (claimsValue) {
-        payload.append('claims', claimsValue)
-      }
+      const payload = createRefreshTokenPayload(config, refreshToken, claimsValue || undefined)
 
       const response = await proxyFetch(tokenEndpoint, {
         method: 'POST',
@@ -262,6 +227,9 @@ export function TokenExchange({
       }
 
       setRefreshResponse(tokenData)
+      if (tokenData.refresh_token) {
+        setRefreshToken(tokenData.refresh_token)
+      }
       onTokenExchangeComplete?.(tokenData)
 
       toast.success(`Successfully refreshed tokens${config.demoMode ? ' (demo mode)' : ''}`)

--- a/src/features/oauthPlayground/utils/oidc-preflight.ts
+++ b/src/features/oauthPlayground/utils/oidc-preflight.ts
@@ -236,53 +236,53 @@ export async function runOidcEndpointPreflight(
 
   const keysToCheck = resolveEndpointsToProbe(requiredEndpoints, includeOptionalEndpoints)
 
-  for (const key of keysToCheck) {
-    const endpointRequired = requiredSet.has(key)
-    const endpointUrl = getStringValue(discoveryResult.config[key])
-    if (!endpointUrl) {
-      endpoints.push({
-        endpoint: key,
-        label: ENDPOINT_LABELS[key],
-        method: ENDPOINT_METHODS[key],
-        status: endpointRequired ? 'fail' : 'warn',
-        required: endpointRequired,
-        reasonCode: 'missing_or_unavailable',
-        message: endpointRequired
-          ? `${ENDPOINT_LABELS[key]} is required but missing in discovery`
-          : 'Optional endpoint unavailable',
-      })
-      continue
-    }
+  const endpointProbeResults = await Promise.all(
+    keysToCheck.map(async (key) => {
+      const endpointRequired = requiredSet.has(key)
+      const endpointUrl = getStringValue(discoveryResult.config[key])
+      if (!endpointUrl) {
+        return {
+          endpoint: key,
+          label: ENDPOINT_LABELS[key],
+          method: ENDPOINT_METHODS[key],
+          status: endpointRequired ? 'fail' : 'warn',
+          required: endpointRequired,
+          reasonCode: 'missing_or_unavailable',
+          message: endpointRequired
+            ? `${ENDPOINT_LABELS[key]} is required but missing in discovery`
+            : 'Optional endpoint unavailable',
+        } satisfies OidcEndpointPreflightResult
+      }
 
-    if (!isValidAbsoluteUrl(endpointUrl)) {
-      endpoints.push({
+      if (!isValidAbsoluteUrl(endpointUrl)) {
+        return {
+          endpoint: key,
+          label: ENDPOINT_LABELS[key],
+          method: ENDPOINT_METHODS[key],
+          status: endpointRequired ? 'fail' : 'warn',
+          required: endpointRequired,
+          reasonCode: 'invalid_url',
+          url: endpointUrl,
+          message: endpointRequired
+            ? `${ENDPOINT_LABELS[key]} is required but has an invalid URL`
+            : `${ENDPOINT_LABELS[key]} has an invalid URL`,
+        } satisfies OidcEndpointPreflightResult
+      }
+
+      return probeEndpoint({
         endpoint: key,
-        label: ENDPOINT_LABELS[key],
-        method: ENDPOINT_METHODS[key],
-        status: endpointRequired ? 'fail' : 'warn',
         required: endpointRequired,
-        reasonCode: 'invalid_url',
         url: endpointUrl,
-        message: endpointRequired
-          ? `${ENDPOINT_LABELS[key]} is required but has an invalid URL`
-          : `${ENDPOINT_LABELS[key]} has an invalid URL`,
+        method: ENDPOINT_METHODS[key],
+        timeoutMs,
+        fetcher,
+        enableServerAssistedProbes,
+        serverAssistedProbeFetcher,
       })
-      continue
-    }
-
-    const probeResult = await probeEndpoint({
-      endpoint: key,
-      required: endpointRequired,
-      url: endpointUrl,
-      method: ENDPOINT_METHODS[key],
-      timeoutMs,
-      fetcher,
-      enableServerAssistedProbes,
-      serverAssistedProbeFetcher,
     })
+  )
 
-    endpoints.push(probeResult)
-  }
+  endpoints.push(...endpointProbeResults)
 
   return {
     issuerUrl: request.issuerUrl,

--- a/src/features/oidcExplorer/components/ConfigInput.tsx
+++ b/src/features/oidcExplorer/components/ConfigInput.tsx
@@ -27,6 +27,44 @@ const stripScheme = (value: string) => value.replace(/^https?:\/\//i, '')
 const deriveScheme = (value: string): 'https://' | 'http://' =>
   value.toLowerCase().startsWith('http://') ? 'http://' : 'https://'
 
+interface IssuerInputState {
+  issuerUrl: string
+  scheme: 'https://' | 'http://'
+  lastControlledIssuerUrl: string
+}
+
+function parseIssuerValue(value: string): Pick<IssuerInputState, 'issuerUrl' | 'scheme'> {
+  const trimmed = value.trim()
+
+  if (!trimmed) {
+    return { issuerUrl: '', scheme: 'https://' }
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    return {
+      issuerUrl: stripScheme(trimmed),
+      scheme: deriveScheme(trimmed),
+    }
+  }
+
+  return { issuerUrl: trimmed, scheme: 'https://' }
+}
+
+const realWorldIssuers = [
+  { name: 'Chick-fil-A', url: 'https://login.my.chick-fil-a.com' },
+  { name: 'Southwest', url: 'https://secure.southwest.com' },
+  { name: 'FedEx', url: 'https://auth.fedex.com' },
+  { name: 'Delta Airlines', url: 'https://signin.delta.com' },
+  { name: 'Google', url: 'https://accounts.google.com' },
+  { name: 'Microsoft', url: 'https://login.microsoftonline.com/common' },
+  { name: 'GitHub', url: 'https://token.actions.githubusercontent.com' },
+  { name: 'Auth0 Demo', url: 'https://samples.auth0.com' },
+  { name: 'Salesforce', url: 'https://login.salesforce.com' },
+  { name: 'Spotify', url: 'https://accounts.spotify.com' },
+  { name: 'Discord', url: 'https://discord.com' },
+  { name: 'Apple', url: 'https://appleid.apple.com' },
+]
+
 export function ConfigInput({
   onFetchRequested,
   isLoading,
@@ -34,59 +72,32 @@ export function ConfigInput({
   onIssuerUrlChange,
   actions,
 }: ConfigInputProps) {
-  const [issuerUrl, setIssuerUrl] = useState('')
-  const [scheme, setScheme] = useState<'https://' | 'http://'>('https://')
-  // Removed hook instantiation
+  const [inputState, setInputState] = useState<IssuerInputState>(() => ({
+    ...parseIssuerValue(controlledIssuerUrl),
+    lastControlledIssuerUrl: controlledIssuerUrl,
+  }))
 
-  // Removed useEffect hooks
+  if (controlledIssuerUrl !== inputState.lastControlledIssuerUrl) {
+    setInputState({
+      ...parseIssuerValue(controlledIssuerUrl),
+      lastControlledIssuerUrl: controlledIssuerUrl,
+    })
+  }
 
+  const { issuerUrl, scheme } = inputState
   const normalizedIssuer = issuerUrl.trim()
   const fullIssuerUrl = normalizedIssuer ? `${scheme}${normalizedIssuer}` : ''
 
-  React.useEffect(() => {
-    const trimmed = controlledIssuerUrl.trim()
-
-    if (!trimmed) {
-      setIssuerUrl('')
-      setScheme('https://')
-      return
-    }
-
-    if (/^https?:\/\//i.test(trimmed)) {
-      setScheme(deriveScheme(trimmed))
-      setIssuerUrl(stripScheme(trimmed))
-      return
-    }
-
-    setIssuerUrl(trimmed)
-  }, [controlledIssuerUrl])
-
   const updateIssuerValue = (value: string, shouldNotify = false) => {
-    const trimmed = value.trim()
+    const nextValue = parseIssuerValue(value)
+    const nextFullIssuerUrl = nextValue.issuerUrl ? `${nextValue.scheme}${nextValue.issuerUrl}` : ''
 
-    if (!trimmed) {
-      setIssuerUrl('')
-      setScheme('https://')
-      if (shouldNotify) {
-        onIssuerUrlChange?.('')
-      }
-      return
-    }
-
-    if (/^https?:\/\//i.test(trimmed)) {
-      const nextScheme = deriveScheme(trimmed)
-      const nextIssuerUrl = stripScheme(trimmed)
-      setScheme(nextScheme)
-      setIssuerUrl(nextIssuerUrl)
-      if (shouldNotify) {
-        onIssuerUrlChange?.(`${nextScheme}${nextIssuerUrl}`)
-      }
-      return
-    }
-
-    setIssuerUrl(trimmed)
+    setInputState((currentState) => ({
+      ...nextValue,
+      lastControlledIssuerUrl: currentState.lastControlledIssuerUrl,
+    }))
     if (shouldNotify) {
-      onIssuerUrlChange?.(`${scheme}${trimmed}`)
+      onIssuerUrlChange?.(nextFullIssuerUrl)
     }
   }
 
@@ -104,29 +115,6 @@ export function ConfigInput({
       handleFetchConfig()
     }
   }
-
-  // Removed exampleIssuers array
-
-  // Real-world public issuers for the random button
-  const realWorldIssuers = [
-    // Original examples
-    { name: 'Chick-fil-A', url: 'https://login.my.chick-fil-a.com' },
-    { name: 'Southwest', url: 'https://secure.southwest.com' },
-    { name: 'FedEx', url: 'https://auth.fedex.com' },
-    { name: 'Delta Airlines', url: 'https://signin.delta.com' },
-
-    // Popular identity providers
-    { name: 'Google', url: 'https://accounts.google.com' },
-    { name: 'Microsoft', url: 'https://login.microsoftonline.com/common' },
-    { name: 'GitHub', url: 'https://token.actions.githubusercontent.com' },
-    { name: 'Auth0 Demo', url: 'https://samples.auth0.com' },
-    { name: 'Salesforce', url: 'https://login.salesforce.com' },
-    { name: 'Spotify', url: 'https://accounts.spotify.com' },
-    { name: 'Discord', url: 'https://discord.com' },
-    { name: 'Apple', url: 'https://appleid.apple.com' },
-  ]
-
-  // Removed handleExampleClick function
 
   const handleRandomExample = () => {
     const randomIndex = Math.floor(Math.random() * realWorldIssuers.length)

--- a/src/features/tokenInspector/components/TokenHistory.tsx
+++ b/src/features/tokenInspector/components/TokenHistory.tsx
@@ -127,17 +127,25 @@ export function TokenHistory({
                     onChange={(e) => setEditName(e.target.value)}
                     className="flex-1 px-2 py-1 text-sm border rounded"
                     placeholder="Token name"
+                    aria-label="Token history name"
                   />
                   <div className="flex gap-1">
                     <Button
                       variant="ghost"
                       size="icon"
                       className="h-6 w-6"
+                      aria-label="Save token name"
                       onClick={() => saveEdit(token.id)}
                     >
                       <Check size={14} />
                     </Button>
-                    <Button variant="ghost" size="icon" className="h-6 w-6" onClick={cancelEdit}>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6"
+                      aria-label="Cancel editing token name"
+                      onClick={cancelEdit}
+                    >
                       <Trash2 size={14} />
                     </Button>
                   </div>
@@ -232,6 +240,7 @@ export function TokenHistory({
                       variant="ghost"
                       size="icon"
                       className="h-6 w-6"
+                      aria-label={`Rename ${token.name || truncateToken(token.token)}`}
                       onClick={(e) => {
                         e.stopPropagation()
                         startEditing(token.id, token.name)
@@ -243,6 +252,7 @@ export function TokenHistory({
                       variant="ghost"
                       size="icon"
                       className="h-6 w-6"
+                      aria-label={`Delete ${token.name || truncateToken(token.token)}`}
                       onClick={(e) => {
                         e.stopPropagation()
                         removeToken(token.id)

--- a/src/features/tokenInspector/components/TokenInput.tsx
+++ b/src/features/tokenInspector/components/TokenInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import EditorImport from 'react-simple-code-editor'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { InfoIcon, TestTubeDiagonal, RotateCcw, Search } from 'lucide-react'
@@ -59,21 +59,11 @@ export function TokenInput({
 }: TokenInputProps) {
   const [isLoadingExample, setIsLoadingExample] = useState(false)
   const [isExampleToken, setIsExampleToken] = useState(false)
-  const [isInitialToken, setIsInitialToken] = useState(!!initialToken)
-
-  // Show "from URL" indicator if token is from URL parameters
-  useEffect(() => {
-    if (initialToken && token === initialToken) {
-      setIsInitialToken(true)
-    } else {
-      setIsInitialToken(false)
-    }
-  }, [initialToken, token])
+  const isInitialToken = Boolean(initialToken && token === initialToken)
 
   const handleSelectTokenFromHistory = (selectedToken: string) => {
     setToken(selectedToken)
     setIsExampleToken(false)
-    setIsInitialToken(false)
     if (onSelectTokenFromHistory) {
       onSelectTokenFromHistory(selectedToken)
     }
@@ -81,7 +71,6 @@ export function TokenInput({
 
   const handleReset = () => {
     setIsExampleToken(false)
-    setIsInitialToken(false)
     onReset()
 
     // Remove the token parameter from the URL without refreshing the page
@@ -215,7 +204,6 @@ export function TokenInput({
               fontFamily: 'monospace',
               fontSize: '0.875rem',
               lineHeight: '1.25rem',
-              outline: 'none',
               minHeight: '120px',
             }}
             className="caret-foreground"

--- a/src/features/tokenInspector/components/TokenTimeline.tsx
+++ b/src/features/tokenInspector/components/TokenTimeline.tsx
@@ -6,6 +6,39 @@ interface TokenTimelineProps {
   payload: any
 }
 
+const tokenTimelineDateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+})
+
+function formatTimeDiff(from: number, to: number) {
+  const diffSecs = Math.floor((to - from) / 1000)
+
+  if (diffSecs < 0) {
+    return `${Math.abs(diffSecs)}s ago`
+  }
+
+  if (diffSecs < 60) {
+    return `${diffSecs}s`
+  } else if (diffSecs < 3600) {
+    return `${Math.floor(diffSecs / 60)}m ${diffSecs % 60}s`
+  } else if (diffSecs < 86400) {
+    const hours = Math.floor(diffSecs / 3600)
+    const mins = Math.floor((diffSecs % 3600) / 60)
+    return `${hours}h ${mins}m`
+  } else {
+    const days = Math.floor(diffSecs / 86400)
+    const hours = Math.floor((diffSecs % 86400) / 3600)
+    return `${days}d ${hours}h`
+  }
+}
+
+function formatTimelineDate(timestamp: number) {
+  return tokenTimelineDateFormatter.format(new Date(timestamp))
+}
+
 export function TokenTimeline({ payload }: TokenTimelineProps) {
   const [currentTime, setCurrentTime] = useState(() => Math.floor(Date.now() / 1000))
 
@@ -49,40 +82,6 @@ export function TokenTimeline({ payload }: TokenTimelineProps) {
   // Calculate percentage elapsed
   const percentElapsed = Math.min(100, (elapsed / totalLifetime) * 100)
 
-  // Format time difference as human-readable
-  const formatTimeDiff = (from: number, to: number) => {
-    const diffSecs = Math.floor((to - from) / 1000)
-
-    if (diffSecs < 0) {
-      return `${Math.abs(diffSecs)}s ago`
-    }
-
-    if (diffSecs < 60) {
-      return `${diffSecs}s`
-    } else if (diffSecs < 3600) {
-      return `${Math.floor(diffSecs / 60)}m ${diffSecs % 60}s`
-    } else if (diffSecs < 86400) {
-      const hours = Math.floor(diffSecs / 3600)
-      const mins = Math.floor((diffSecs % 3600) / 60)
-      return `${hours}h ${mins}m`
-    } else {
-      const days = Math.floor(diffSecs / 86400)
-      const hours = Math.floor((diffSecs % 86400) / 3600)
-      return `${days}d ${hours}h`
-    }
-  }
-
-  // Format date more concisely for mobile
-  const formatDate = (timestamp: number) => {
-    const date = new Date(timestamp)
-    return new Intl.DateTimeFormat('en-US', {
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    }).format(date)
-  }
-
   return (
     <div className="space-y-6">
       <div className="relative pt-16 md:pt-12 pb-8 md:pb-4">
@@ -96,13 +95,13 @@ export function TokenTimeline({ payload }: TokenTimelineProps) {
           {/* Start label - stack on mobile, side-by-side on desktop */}
           <div className="absolute left-0 top-[-3.5rem] md:top-[-2rem] text-xs font-mono text-left md:transform-none max-w-[150px] md:max-w-none break-words md:whitespace-nowrap">
             <div className="font-semibold">Issued:</div>
-            <div>{formatDate(issuedAt)}</div>
+            <div>{formatTimelineDate(issuedAt)}</div>
           </div>
 
           {/* End label - stack on mobile, side-by-side on desktop */}
           <div className="absolute right-0 top-[-3.5rem] md:top-[-2rem] text-xs font-mono text-right md:transform-none max-w-[150px] md:max-w-none break-words md:whitespace-nowrap">
             <div className="font-semibold">{now > expiration ? 'Expired:' : 'Expires:'}</div>
-            <div>{formatDate(expiration)}</div>
+            <div>{formatTimelineDate(expiration)}</div>
           </div>
         </div>
       </div>
@@ -116,7 +115,7 @@ export function TokenTimeline({ payload }: TokenTimelineProps) {
               className="text-xs text-muted-foreground truncate"
               title={new Date(issuedAt).toLocaleString()}
             >
-              {formatDate(issuedAt)}
+              {formatTimelineDate(issuedAt)}
             </p>
           </div>
         </div>
@@ -131,7 +130,7 @@ export function TokenTimeline({ payload }: TokenTimelineProps) {
               className="text-xs text-muted-foreground truncate"
               title={new Date(expiration).toLocaleString()}
             >
-              {formatDate(expiration)}
+              {formatTimelineDate(expiration)}
             </p>
           </div>
         </div>
@@ -145,7 +144,7 @@ export function TokenTimeline({ payload }: TokenTimelineProps) {
                 className="text-xs text-muted-foreground truncate"
                 title={new Date(authTime).toLocaleString()}
               >
-                {formatDate(authTime)}
+                {formatTimelineDate(authTime)}
               </p>
             </div>
           </div>

--- a/src/features/tokenInspector/index.tsx
+++ b/src/features/tokenInspector/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import * as jose from 'jose'
 import { Card, CardContent } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -31,6 +31,7 @@ interface TokenInspectorProps {
 
 export function TokenInspector({ initialToken = null }: TokenInspectorProps) {
   const [token, setToken] = useState(initialToken || '')
+  const lastInitialTokenRef = useRef(initialToken)
   const [jwks, setJwks] = useState<jose.JSONWebKeySet | null>(null) // Holds the currently loaded JWKS
   const [activeTab, setActiveTab] = useState('payload')
   const [manualIssuerUrl, setManualIssuerUrl] = useState('') // Manual issuer URL override
@@ -72,21 +73,12 @@ export function TokenInspector({ initialToken = null }: TokenInspectorProps) {
     }
   }, [issuerUrl, oidcConfig, selectedEnvironment])
 
-  // Effect to handle initial token from URL
-  useEffect(() => {
-    if (initialToken && token !== initialToken) {
-      // Process only if initialToken exists and hasn't been processed
-      if (import.meta?.env?.DEV) {
-        console.log(
-          'Processing initial token from URL parameter:',
-          initialToken.substring(0, 10) + '...'
-        )
-      }
-      setToken(initialToken) // Set the token state
-      // Decode will happen via the useEffect watching `token` state below
+  if (initialToken !== lastInitialTokenRef.current) {
+    lastInitialTokenRef.current = initialToken
+    if (initialToken) {
+      setToken(initialToken)
     }
-    // Intentionally run only when initialToken prop changes
-  }, [initialToken])
+  }
 
   // Effect to decode token whenever the 'token' state changes
   useEffect(() => {

--- a/src/features/tokenInspector/pages/index.tsx
+++ b/src/features/tokenInspector/pages/index.tsx
@@ -1,29 +1,11 @@
 import { TokenInspector } from '@/features/tokenInspector'
 import { PageContainer, PageHeader } from '@/components/page'
 import { KeyRound } from 'lucide-react'
-// Removed unused import: import { useUrlParams } from "@/hooks";
-import { useEffect, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 
 export default function TokenInspectorPage() {
-  const [urlToken, setUrlToken] = useState<string | null>(null)
   const location = useLocation()
-
-  // Extract token from URL parameters whenever URL changes
-  // This ensures it works both for initial load and subsequent navigations
-  useEffect(() => {
-    const searchParams = new URLSearchParams(location.search)
-    const tokenParam = searchParams.get('token')
-
-    if (tokenParam) {
-      if (import.meta?.env?.DEV) {
-        console.log('Token found in URL parameters:', tokenParam.substring(0, 10) + '...')
-      }
-      setUrlToken(tokenParam)
-    } else {
-      setUrlToken(null)
-    }
-  }, [location.search]) // React to location.search changes
+  const urlToken = new URLSearchParams(location.search).get('token')
 
   return (
     <PageContainer maxWidth="full">

--- a/src/hooks/use-async-fetch.ts
+++ b/src/hooks/use-async-fetch.ts
@@ -31,6 +31,7 @@ export function useAsyncFetch<T>(
   asyncFunction: (...args: unknown[]) => Promise<T>,
   options: UseAsyncFetchOptions<T> = {}
 ): UseAsyncFetchResult<T> {
+  const { cache, getCacheKey, onError, onSuccess, shouldExecute } = options
   const [data, setData] = useState<T | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<Error | null>(null)
@@ -41,19 +42,19 @@ export function useAsyncFetch<T>(
   const execute = useCallback(
     async (...args: unknown[]): Promise<T | null> => {
       // Check if we should execute
-      if (options.shouldExecute && !options.shouldExecute(...args)) {
+      if (shouldExecute && !shouldExecute(...args)) {
         return null
       }
 
       // Check cache if available
-      if (options.cache && options.getCacheKey) {
-        const cacheKey = options.getCacheKey(...args)
-        const cached = options.cache.get(cacheKey)
+      if (cache && getCacheKey) {
+        const cacheKey = getCacheKey(...args)
+        const cached = cache.get(cacheKey)
         if (cached) {
           setData(cached)
           setError(null)
           setIsLoading(false)
-          options.onSuccess?.(cached)
+          onSuccess?.(cached)
           return cached
         }
       }
@@ -71,12 +72,12 @@ export function useAsyncFetch<T>(
         setData(result)
 
         // Store in cache if available
-        if (options.cache && options.getCacheKey) {
-          const cacheKey = options.getCacheKey(...args)
-          options.cache.set(cacheKey, result)
+        if (cache && getCacheKey) {
+          const cacheKey = getCacheKey(...args)
+          cache.set(cacheKey, result)
         }
 
-        options.onSuccess?.(result)
+        onSuccess?.(result)
         return result
       } catch (err) {
         if (!isMountedRef.current) {
@@ -86,7 +87,7 @@ export function useAsyncFetch<T>(
         const error = err instanceof Error ? err : new Error('An unknown error occurred')
         setError(error)
         setData(null)
-        options.onError?.(error)
+        onError?.(error)
         return null
       } finally {
         if (isMountedRef.current) {
@@ -94,7 +95,7 @@ export function useAsyncFetch<T>(
         }
       }
     },
-    [asyncFunction, options]
+    [asyncFunction, cache, getCacheKey, onError, onSuccess, shouldExecute]
   )
 
   const reset = useCallback(() => {

--- a/src/lib/jwt/verify-signature-with-refresh.ts
+++ b/src/lib/jwt/verify-signature-with-refresh.ts
@@ -13,13 +13,15 @@ interface VerifyResult {
  * @param jwksUri The URI where JWKS can be fetched
  * @param initialJwks The initial JWKS to try (from cache or hook state)
  * @param onJwksRefresh Optional callback when JWKS is refreshed
+ * @param fetchJwks Fetch implementation for refreshing JWKS
  * @returns Promise<VerifyResult>
  */
 export async function verifySignatureWithRefresh(
   token: string,
   jwksUri: string,
   initialJwks: JSONWebKeySet,
-  onJwksRefresh?: (newJwks: JSONWebKeySet) => void
+  onJwksRefresh?: (newJwks: JSONWebKeySet) => void,
+  fetchJwks: typeof proxyFetch = proxyFetch
 ): Promise<VerifyResult> {
   try {
     if (import.meta?.env?.DEV) {
@@ -106,7 +108,7 @@ export async function verifySignatureWithRefresh(
         jwksCache.remove(jwksUri)
 
         // Fetch fresh JWKS
-        const response = await proxyFetch(jwksUri)
+        const response = await fetchJwks(jwksUri)
         if (!response.ok) {
           throw new Error(`Failed to fetch JWKS: ${response.status} ${response.statusText}`)
         }

--- a/src/lib/proxy-fetch.ts
+++ b/src/lib/proxy-fetch.ts
@@ -8,7 +8,11 @@
  * @param options Fetch options
  * @returns The fetch response
  */
-export async function proxyFetch(url: string, options?: RequestInit): Promise<Response> {
+export async function proxyFetch(
+  url: string,
+  options?: RequestInit,
+  fetcher: typeof fetch = fetch
+): Promise<Response> {
   // Determine if we need to use the proxy
   const useProxy = needsProxy(url)
 
@@ -21,11 +25,11 @@ export async function proxyFetch(url: string, options?: RequestInit): Promise<Re
       : '/api/cors-proxy/'
 
     const proxyUrl = `${baseProxyUrl}${encodeURIComponent(url)}`
-    return fetch(proxyUrl, options)
+    return fetcher(proxyUrl, options)
   }
 
   // Otherwise, fetch directly
-  return fetch(url, options)
+  return fetcher(url, options)
 }
 
 /**

--- a/src/tests/lib/proxy-fetch.test.ts
+++ b/src/tests/lib/proxy-fetch.test.ts
@@ -1,7 +1,6 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
 import { proxyFetch } from '@/lib/proxy-fetch'
 
-const originalFetch = globalThis.fetch
 const fetchMock = mock(async () => {
   return {
     ok: true,
@@ -17,19 +16,14 @@ const getProxyBase = () =>
 describe('proxyFetch', () => {
   beforeEach(() => {
     fetchMock.mockReset()
-    globalThis.fetch = fetchMock as any
     if (globalThis.window) {
       globalThis.window.location.hostname = 'app.example.com'
     }
   })
 
-  afterEach(() => {
-    globalThis.fetch = originalFetch
-  })
-
   test('proxies well-known configuration requests', async () => {
     const targetUrl = 'https://issuer.com/.well-known/openid-configuration'
-    await proxyFetch(targetUrl)
+    await proxyFetch(targetUrl, undefined, fetchMock as typeof fetch)
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock.mock.calls[0][0]).toBe(getProxyBase() + encodeURIComponent(targetUrl))
@@ -37,35 +31,35 @@ describe('proxyFetch', () => {
 
   test('proxies JWKS endpoint requests', async () => {
     const targetUrl = 'https://issuer.com/oauth2/v1/certs'
-    await proxyFetch(targetUrl)
+    await proxyFetch(targetUrl, undefined, fetchMock as typeof fetch)
 
     expect(fetchMock.mock.calls[0][0]).toBe(getProxyBase() + encodeURIComponent(targetUrl))
   })
 
   test('proxies SAML metadata requests', async () => {
     const targetUrl = 'https://idp.example.com/FederationMetadata/2007-06/FederationMetadata.xml'
-    await proxyFetch(targetUrl)
+    await proxyFetch(targetUrl, undefined, fetchMock as typeof fetch)
 
     expect(fetchMock.mock.calls[0][0]).toBe(getProxyBase() + encodeURIComponent(targetUrl))
   })
 
   test('bypasses proxy for same-domain requests', async () => {
     const sameDomainUrl = 'https://app.example.com/api/data'
-    await proxyFetch(sameDomainUrl)
+    await proxyFetch(sameDomainUrl, undefined, fetchMock as typeof fetch)
 
     expect(fetchMock.mock.calls[0][0]).toBe(sameDomainUrl)
   })
 
   test('bypasses proxy for localhost targets', async () => {
     const localhostUrl = 'http://127.0.0.1:8787/health'
-    await proxyFetch(localhostUrl)
+    await proxyFetch(localhostUrl, undefined, fetchMock as typeof fetch)
 
     expect(fetchMock.mock.calls[0][0]).toBe(localhostUrl)
   })
 
   test('returns direct fetch for invalid URLs', async () => {
     const invalidUrl = 'not-a-valid-url'
-    await proxyFetch(invalidUrl)
+    await proxyFetch(invalidUrl, undefined, fetchMock as typeof fetch)
 
     expect(fetchMock.mock.calls[0][0]).toBe(invalidUrl)
   })

--- a/src/tests/lib/proxy-fetch.test.ts
+++ b/src/tests/lib/proxy-fetch.test.ts
@@ -1,12 +1,17 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import { beforeEach, describe, expect, test } from 'bun:test'
 import { proxyFetch } from '@/lib/proxy-fetch'
 
-const fetchMock = mock(async () => {
+type FetchCall = Parameters<typeof fetch>
+
+let fetchCalls: FetchCall[] = []
+
+const fetchStub = async (...args: FetchCall) => {
+  fetchCalls.push(args)
   return {
     ok: true,
     status: 200,
   } as Response
-})
+}
 
 const getProxyBase = () =>
   ((import.meta as any)?.env?.DEV
@@ -15,7 +20,7 @@ const getProxyBase = () =>
 
 describe('proxyFetch', () => {
   beforeEach(() => {
-    fetchMock.mockReset()
+    fetchCalls = []
     if (globalThis.window) {
       globalThis.window.location.hostname = 'app.example.com'
     }
@@ -23,44 +28,44 @@ describe('proxyFetch', () => {
 
   test('proxies well-known configuration requests', async () => {
     const targetUrl = 'https://issuer.com/.well-known/openid-configuration'
-    await proxyFetch(targetUrl, undefined, fetchMock as typeof fetch)
+    await proxyFetch(targetUrl, undefined, fetchStub)
 
-    expect(fetchMock).toHaveBeenCalledTimes(1)
-    expect(fetchMock.mock.calls[0][0]).toBe(getProxyBase() + encodeURIComponent(targetUrl))
+    expect(fetchCalls).toHaveLength(1)
+    expect(fetchCalls[0][0]).toBe(getProxyBase() + encodeURIComponent(targetUrl))
   })
 
   test('proxies JWKS endpoint requests', async () => {
     const targetUrl = 'https://issuer.com/oauth2/v1/certs'
-    await proxyFetch(targetUrl, undefined, fetchMock as typeof fetch)
+    await proxyFetch(targetUrl, undefined, fetchStub)
 
-    expect(fetchMock.mock.calls[0][0]).toBe(getProxyBase() + encodeURIComponent(targetUrl))
+    expect(fetchCalls[0][0]).toBe(getProxyBase() + encodeURIComponent(targetUrl))
   })
 
   test('proxies SAML metadata requests', async () => {
     const targetUrl = 'https://idp.example.com/FederationMetadata/2007-06/FederationMetadata.xml'
-    await proxyFetch(targetUrl, undefined, fetchMock as typeof fetch)
+    await proxyFetch(targetUrl, undefined, fetchStub)
 
-    expect(fetchMock.mock.calls[0][0]).toBe(getProxyBase() + encodeURIComponent(targetUrl))
+    expect(fetchCalls[0][0]).toBe(getProxyBase() + encodeURIComponent(targetUrl))
   })
 
   test('bypasses proxy for same-domain requests', async () => {
     const sameDomainUrl = 'https://app.example.com/api/data'
-    await proxyFetch(sameDomainUrl, undefined, fetchMock as typeof fetch)
+    await proxyFetch(sameDomainUrl, undefined, fetchStub)
 
-    expect(fetchMock.mock.calls[0][0]).toBe(sameDomainUrl)
+    expect(fetchCalls[0][0]).toBe(sameDomainUrl)
   })
 
   test('bypasses proxy for localhost targets', async () => {
     const localhostUrl = 'http://127.0.0.1:8787/health'
-    await proxyFetch(localhostUrl, undefined, fetchMock as typeof fetch)
+    await proxyFetch(localhostUrl, undefined, fetchStub)
 
-    expect(fetchMock.mock.calls[0][0]).toBe(localhostUrl)
+    expect(fetchCalls[0][0]).toBe(localhostUrl)
   })
 
   test('returns direct fetch for invalid URLs', async () => {
     const invalidUrl = 'not-a-valid-url'
-    await proxyFetch(invalidUrl, undefined, fetchMock as typeof fetch)
+    await proxyFetch(invalidUrl, undefined, fetchStub)
 
-    expect(fetchMock.mock.calls[0][0]).toBe(invalidUrl)
+    expect(fetchCalls[0][0]).toBe(invalidUrl)
   })
 })

--- a/src/tests/lib/verify-signature-with-refresh.test.ts
+++ b/src/tests/lib/verify-signature-with-refresh.test.ts
@@ -37,11 +37,6 @@ const mockProxyFetch = mock((): Promise<MockResponse> => {
   })
 })
 
-// Mock the proxyFetch module
-mock.module('@/lib/proxy-fetch', () => ({
-  proxyFetch: mockProxyFetch,
-}))
-
 // Mock jwtVerify to avoid actual crypto operations in tests
 const mockJwtVerify = mock(async () => {
   throw new Error('Signature verification failed')
@@ -128,7 +123,13 @@ describe('verifySignatureWithRefresh', () => {
     const tokenWithWrongKid =
       'eyJhbGciOiJSUzI1NiIsImtpZCI6Indyb25nLWtleSJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIn0.signature'
 
-    const result = await verifySignatureWithRefresh(tokenWithWrongKid, mockJwksUri, mockJwks)
+    const result = await verifySignatureWithRefresh(
+      tokenWithWrongKid,
+      mockJwksUri,
+      mockJwks,
+      undefined,
+      mockProxyFetch as any
+    )
 
     expect(result.valid).toBe(false)
     expect(result.error).toContain('No key with ID "wrong-key" found in the JWKS')
@@ -157,7 +158,8 @@ describe('verifySignatureWithRefresh', () => {
       (newJwks: JSONWebKeySet) => {
         refreshCalled = true
         expect(newJwks).toEqual(mockJwksRotated)
-      }
+      },
+      mockProxyFetch as any
     )
 
     // The verification will still fail due to invalid test keys,
@@ -181,7 +183,13 @@ describe('verifySignatureWithRefresh', () => {
       })
     })
 
-    const result = await verifySignatureWithRefresh(tokenNewKey, mockJwksUri, mockJwks)
+    const result = await verifySignatureWithRefresh(
+      tokenNewKey,
+      mockJwksUri,
+      mockJwks,
+      undefined,
+      mockProxyFetch as any
+    )
 
     expect(result.valid).toBe(false)
     expect(result.error).toContain('JWKS refresh also failed')
@@ -201,7 +209,13 @@ describe('verifySignatureWithRefresh', () => {
       })
     })
 
-    const result = await verifySignatureWithRefresh(tokenNewKey, mockJwksUri, mockJwks)
+    const result = await verifySignatureWithRefresh(
+      tokenNewKey,
+      mockJwksUri,
+      mockJwks,
+      undefined,
+      mockProxyFetch as any
+    )
 
     expect(result.valid).toBe(false)
     expect(result.error).toContain('JWKS refresh also failed')


### PR DESCRIPTION
## Summary
- refresh the homepage into a clearer IAM tool directory
- clean up React state/effect patterns across token inspector, OIDC, OAuth playground, and shared UI
- add accessibility and keyboard handling fixes for history, environment, LDAP, and icon controls
- parallelize OIDC endpoint preflight probes and update stale e2e homepage assertions

## Validation
- `bun run lint`
- `bun run test` (428 passed)
- `bun run e2e:smoke` (37 passed)
- `bun run e2e:check-selector-contract`
- `bun run e2e:check-no-sleeps`
- `bun run build`
- `git diff --check`