### PR TITLE
feat: harden clipboard copy flows and expand playground coverage

### DIFF
--- a/e2e/tests/oauth-playground-auth-code.e2e.ts
+++ b/e2e/tests/oauth-playground-auth-code.e2e.ts
@@ -139,9 +139,9 @@ test.describe('OAuth Playground - Auth Code with PKCE', () => {
     await expect(regenerateButton).toBeVisible()
     await regenerateButton.click()
 
-    await expect(page.locator('text=Code Verifier').first()).toBeVisible()
-    await expect(page.locator('text=Code Challenge (S256)')).toBeVisible()
-    await expect(page.locator('text=State').first()).toBeVisible()
+    await expect(page.getByLabel('Code Verifier')).not.toHaveValue('')
+    await expect(page.getByLabel('Code Challenge (S256)')).not.toHaveValue('')
+    await expect(page.getByLabel('State')).not.toHaveValue('')
   })
 
   test('should show step indicators', async ({ page }) => {

--- a/e2e/tests/oauth-playground-userinfo.e2e.ts
+++ b/e2e/tests/oauth-playground-userinfo.e2e.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test'
+import { TestUtils } from '../helpers/test-utils'
+import { selectors } from '../helpers/selectors'
+
+test.describe('OAuth Playground - UserInfo', () => {
+  let utils: TestUtils
+
+  test.beforeEach(async ({ page }) => {
+    utils = new TestUtils(page)
+    await utils.navigateTo('/oauth-playground/userinfo')
+    await expect(page.locator('text=OAuth UserInfo Endpoint')).toBeVisible()
+  })
+
+  test('should request demo UserInfo claims with a generated access token', async ({ page }) => {
+    await page.click(selectors.oauthPlayground.demoModeSwitch)
+
+    await expect(page.locator(selectors.oauthPlayground.userInfoEndpointInput)).toHaveValue(
+      /\/api\/userinfo$/
+    )
+    await expect(page.locator(selectors.oauthPlayground.userInfoAccessTokenInput)).not.toHaveValue(
+      ''
+    )
+
+    await page.click(selectors.oauthPlayground.userInfoSubmitButton)
+
+    await expect(page.locator('text=UserInfo Result')).toBeVisible()
+    await expect(page.locator('p').filter({ hasText: 'Example User' })).toBeVisible()
+    await expect(page.locator('p').filter({ hasText: 'example@iam.tools' })).toBeVisible()
+    await expect(page.locator('text=Demo Response')).toBeVisible()
+    await expect(page.locator('text=Subject identifier for the authenticated user.')).toBeVisible()
+  })
+})

--- a/e2e/tests/saml-sp-metadata.e2e.ts
+++ b/e2e/tests/saml-sp-metadata.e2e.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test'
+import { TestUtils } from '../helpers/test-utils'
+
+test.describe('SAML SP Metadata Generator', () => {
+  let utils: TestUtils
+
+  test.beforeEach(async ({ page }) => {
+    utils = new TestUtils(page)
+    await utils.navigateTo('/saml/sp-metadata')
+    await expect(page.locator('#main-content').getByText('SP Metadata Generator')).toBeVisible()
+  })
+
+  test('should escape metadata fields and include an optional signing certificate', async ({
+    page,
+  }) => {
+    const consoleErrors: string[] = []
+    page.on('console', (message) => {
+      if (message.type() === 'error') {
+        consoleErrors.push(message.text())
+      }
+    })
+
+    await page.locator('#sp-entity-id').fill('https://sp.example.com/entity?team=iam&name=<Admin>')
+    await page.locator('#sp-acs-url').fill('https://sp.example.com/saml/acs?return=<ok>&x=1')
+    await page.locator('#sp-slo-url').fill('https://sp.example.com/saml/logout')
+    await page.locator('#sp-name-id-format').fill('urn:example:nameid')
+
+    await expect(page.locator('body')).toContainText(
+      'entityID="https://sp.example.com/entity?team=iam&amp;name=&lt;Admin&gt;"'
+    )
+    await expect(page.locator('body')).toContainText(
+      'Location="https://sp.example.com/saml/acs?return=&lt;ok&gt;&amp;x=1"'
+    )
+    await expect(page.locator('body')).toContainText('SingleLogoutService')
+    await expect(page.locator('body')).toContainText('urn:example:nameid')
+
+    await page.getByRole('switch', { name: 'Include signing certificate' }).click()
+    await page.locator('#sp-certificate').fill('MIICDEMO123')
+
+    await expect(page.locator('body')).toContainText(
+      '<ds:X509Certificate>MIICDEMO123</ds:X509Certificate>'
+    )
+
+    await page.locator('[data-testid="saml-sp-metadata-copy-button"]').click()
+    expect(consoleErrors).toEqual([])
+  })
+})

--- a/src/components/common/CopyButton.tsx
+++ b/src/components/common/CopyButton.tsx
@@ -27,9 +27,11 @@ export function CopyButton({
 }: CopyButtonProps) {
   const { copy, copied } = useClipboard()
 
-  const handleCopy = () => {
-    copy(text)
-    onCopy?.()
+  const handleCopy = async () => {
+    const success = await copy(text)
+    if (success) {
+      onCopy?.()
+    }
   }
 
   // Provide aria-label for icon-only buttons (when showText is false)

--- a/src/features/ldap/pages/ldif-builder/index.tsx
+++ b/src/features/ldap/pages/ldif-builder/index.tsx
@@ -26,6 +26,7 @@ import {
 import { Label } from '@/components/ui/label'
 import { PageContainer, PageHeader } from '@/components/page'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { copyTextToClipboard } from '@/hooks/use-clipboard'
 import { useSavedSchemas } from '../../hooks/useSavedSchemas'
 import { useSchemaSummaries } from '../../hooks/useSchemaDetails'
 import { useLdifValidation } from '../../hooks/useLdifValidation'
@@ -134,13 +135,12 @@ export default function LdifBuilderPage() {
   }
 
   const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(ldifText)
+    const copied = await copyTextToClipboard(ldifText)
+
+    if (copied) {
       toast.success('Copied LDIF to clipboard')
-    } catch (error) {
-      toast.error('Copy failed', {
-        description: error instanceof Error ? error.message : String(error),
-      })
+    } else {
+      toast.error('Copy failed')
     }
   }
 

--- a/src/features/oauthPlayground/components/ConfigurationForm.tsx
+++ b/src/features/oauthPlayground/components/ConfigurationForm.tsx
@@ -439,6 +439,7 @@ export function ConfigurationForm({
           />
 
           <FormFieldInput
+            id="oauth-redirect-uri"
             label="Redirect URI"
             value={redirectUri}
             readOnly
@@ -468,6 +469,7 @@ export function ConfigurationForm({
             </div>
 
             <FormFieldInput
+              id="oauth-code-verifier"
               label="Code Verifier"
               value={codeVerifier}
               readOnly
@@ -475,6 +477,7 @@ export function ConfigurationForm({
             />
 
             <FormFieldInput
+              id="oauth-code-challenge"
               label="Code Challenge (S256)"
               value={codeChallenge}
               readOnly
@@ -482,6 +485,7 @@ export function ConfigurationForm({
             />
 
             <FormFieldInput
+              id="oauth-state"
               label="State"
               value={state}
               readOnly

--- a/src/features/saml/components/LaunchTab.tsx
+++ b/src/features/saml/components/LaunchTab.tsx
@@ -67,8 +67,14 @@ export function LaunchTab({
 
           <div className="mt-4 border-t pt-4 grid gap-3">
             <div className="flex items-center gap-2">
-              <Switch checked={enableSigning} onCheckedChange={onEnableSigningChange} />
-              <span className="text-sm">Sign Redirect (adds Signature)</span>
+              <Switch
+                id="saml-launch-enable-signing"
+                checked={enableSigning}
+                onCheckedChange={onEnableSigningChange}
+              />
+              <Label htmlFor="saml-launch-enable-signing" className="text-sm">
+                Sign Redirect (adds Signature)
+              </Label>
             </div>
             {enableSigning && (
               <>

--- a/src/features/saml/components/RequestFormFields.tsx
+++ b/src/features/saml/components/RequestFormFields.tsx
@@ -58,6 +58,7 @@ export function RequestFormFields({
   const requestIdInputId = 'saml-request-id-input'
   const isPassiveSelectId = 'saml-request-is-passive-select'
   const nameIdFormatSelectId = 'saml-request-name-id-format-select'
+  const forceAuthnSwitchId = 'saml-request-force-authn-switch'
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] gap-4 min-w-0">
@@ -167,8 +168,14 @@ export function RequestFormFields({
       </div>
       <div className="grid md:grid-cols-2 gap-4 items-center">
         <div className="flex items-center gap-2">
-          <Switch checked={forceAuthn} onCheckedChange={onForceAuthnChange} />
-          <span className="text-sm">ForceAuthn</span>
+          <Switch
+            id={forceAuthnSwitchId}
+            checked={forceAuthn}
+            onCheckedChange={onForceAuthnChange}
+          />
+          <Label htmlFor={forceAuthnSwitchId} className="text-sm">
+            ForceAuthn
+          </Label>
         </div>
         <div className="grid gap-2 min-w-0">
           <Label htmlFor={isPassiveSelectId} className="text-sm">

--- a/src/features/saml/hooks/useSamlRequestBuilder.ts
+++ b/src/features/saml/hooks/useSamlRequestBuilder.ts
@@ -6,6 +6,7 @@ import {
   encodeBase64,
 } from '@/features/saml/utils/saml-request'
 import { signRedirectRequest, type RedirectSigAlg } from '@/features/saml/utils/redirect-signing'
+import { copyTextToClipboard } from '@/hooks/use-clipboard'
 
 type Binding = 'HTTP-Redirect' | 'HTTP-POST'
 type IsPassiveValue = 'unset' | 'true' | 'false'
@@ -149,10 +150,11 @@ export function useSamlRequestBuilder(): UseSamlRequestBuilderReturn {
 
   // Copy to clipboard helper
   const copy = useCallback(async (text: string, label = 'Copied') => {
-    try {
-      await navigator.clipboard.writeText(text)
+    const copied = await copyTextToClipboard(text)
+
+    if (copied) {
       toast.success(label)
-    } catch {
+    } else {
       toast.error('Copy failed')
     }
   }, [])

--- a/src/features/saml/pages/sp-metadata/index.tsx
+++ b/src/features/saml/pages/sp-metadata/index.tsx
@@ -10,6 +10,7 @@ import { PageContainer, PageHeader } from '@/components/page'
 import { FileCog } from 'lucide-react'
 import { JsonDisplay } from '@/components/common/JsonDisplay'
 import { formatXml } from '@/lib/format/xml'
+import { copyTextToClipboard } from '@/hooks/use-clipboard'
 
 function xmlEscape(value: string) {
   return value
@@ -36,10 +37,11 @@ export default function SpMetadataGeneratorPage() {
   )
 
   const copy = async () => {
-    try {
-      await navigator.clipboard.writeText(xml)
+    const copied = await copyTextToClipboard(xml)
+
+    if (copied) {
       toast.success('Metadata copied')
-    } catch {
+    } else {
       toast.error('Copy failed')
     }
   }
@@ -88,8 +90,14 @@ export default function SpMetadataGeneratorPage() {
             </div>
           </div>
           <div className="flex items-center gap-2">
-            <Switch checked={includeCert} onCheckedChange={setIncludeCert} />
-            <span className="text-sm">Include signing certificate</span>
+            <Switch
+              id="sp-include-signing-certificate"
+              checked={includeCert}
+              onCheckedChange={setIncludeCert}
+            />
+            <Label htmlFor="sp-include-signing-certificate" className="text-sm">
+              Include signing certificate
+            </Label>
           </div>
           {includeCert && (
             <div className="grid gap-2">
@@ -108,7 +116,12 @@ export default function SpMetadataGeneratorPage() {
           )}
           <div className="flex justify-between items-center">
             <div className="text-sm text-muted-foreground">Generated XML</div>
-            <Button variant="outline" size="sm" onClick={copy}>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={copy}
+              data-testid="saml-sp-metadata-copy-button"
+            >
               Copy
             </Button>
           </div>

--- a/src/hooks/use-clipboard.ts
+++ b/src/hooks/use-clipboard.ts
@@ -5,6 +5,40 @@ interface UseClipboardOptions {
   successDuration?: number
 }
 
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+  const copyWithTextArea = () => {
+    if (typeof document === 'undefined') return false
+
+    const textArea = document.createElement('textarea')
+    textArea.value = text
+    textArea.setAttribute('readonly', '')
+    textArea.style.position = 'fixed'
+    textArea.style.left = '-999999px'
+    textArea.style.top = '-999999px'
+    document.body.appendChild(textArea)
+
+    textArea.focus()
+    textArea.select()
+
+    try {
+      return document.execCommand?.('copy') ?? false
+    } finally {
+      document.body.removeChild(textArea)
+    }
+  }
+
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text)
+      return true
+    }
+  } catch {
+    return copyWithTextArea()
+  }
+
+  return copyWithTextArea()
+}
+
 /**
  * Hook for copying text to the clipboard
  * @param options Configuration options
@@ -15,47 +49,20 @@ export function useClipboard({ successDuration = 2000 }: UseClipboardOptions = {
 
   const copy = useCallback(
     async (text: string) => {
-      try {
-        if (navigator.clipboard) {
-          await navigator.clipboard.writeText(text)
-          setCopied(true)
+      const success = await copyTextToClipboard(text)
 
-          // Reset copied state after specified duration
-          setTimeout(() => {
-            setCopied(false)
-          }, successDuration)
-
-          return true
-        } else {
-          // Fallback for browsers without clipboard API
-          const textArea = document.createElement('textarea')
-          textArea.value = text
-
-          // Make the textarea out of viewport
-          textArea.style.position = 'fixed'
-          textArea.style.left = '-999999px'
-          textArea.style.top = '-999999px'
-          document.body.appendChild(textArea)
-
-          textArea.focus()
-          textArea.select()
-
-          const success = document.execCommand('copy')
-          document.body.removeChild(textArea)
-
-          if (success) {
-            setCopied(true)
-            setTimeout(() => {
-              setCopied(false)
-            }, successDuration)
-            return true
-          }
-          return false
-        }
-      } catch (error) {
-        console.error('Failed to copy text: ', error)
+      if (!success) {
         return false
       }
+
+      setCopied(true)
+
+      // Reset copied state after specified duration
+      setTimeout(() => {
+        setCopied(false)
+      }, successDuration)
+
+      return true
     },
     [successDuration]
   )

--- a/src/tests/hooks/use-clipboard.test.ts
+++ b/src/tests/hooks/use-clipboard.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { copyTextToClipboard, useClipboard } from '@/hooks/use-clipboard'
+import '../utils/dom-setup'
+
+const originalClipboard = navigator.clipboard
+const originalExecCommand = document.execCommand
+
+function setClipboard(writeText?: (text: string) => Promise<void>) {
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: writeText ? { writeText } : undefined,
+  })
+}
+
+function setExecCommand(execCommand?: (commandId: string) => boolean) {
+  Object.defineProperty(document, 'execCommand', {
+    configurable: true,
+    value: execCommand,
+  })
+}
+
+afterEach(() => {
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: originalClipboard,
+  })
+  Object.defineProperty(document, 'execCommand', {
+    configurable: true,
+    value: originalExecCommand,
+  })
+  document.body.innerHTML = ''
+})
+
+describe('copyTextToClipboard', () => {
+  test('uses the Clipboard API when it succeeds', async () => {
+    const writes: string[] = []
+    setClipboard(async (text) => {
+      writes.push(text)
+    })
+    setExecCommand(() => {
+      throw new Error('fallback should not run')
+    })
+
+    await expect(copyTextToClipboard('hello')).resolves.toBe(true)
+    expect(writes).toEqual(['hello'])
+  })
+
+  test('falls back to textarea copy when Clipboard API permission is denied', async () => {
+    let fallbackCommand = ''
+    setClipboard(async () => {
+      throw new DOMException('Write permission denied', 'NotAllowedError')
+    })
+    setExecCommand((commandId) => {
+      fallbackCommand = commandId
+      const active = document.activeElement as HTMLTextAreaElement | null
+      expect(active?.value).toBe('fallback text')
+      return true
+    })
+
+    await expect(copyTextToClipboard('fallback text')).resolves.toBe(true)
+    expect(fallbackCommand).toBe('copy')
+    expect(document.querySelector('textarea')).toBeNull()
+  })
+
+  test('returns false when Clipboard API and fallback copy both fail', async () => {
+    setClipboard(async () => {
+      throw new Error('clipboard unavailable')
+    })
+    setExecCommand(() => false)
+
+    await expect(copyTextToClipboard('not copied')).resolves.toBe(false)
+  })
+})
+
+describe('useClipboard', () => {
+  test('sets copied only after a successful fallback copy', async () => {
+    setClipboard(async () => {
+      throw new DOMException('Write permission denied', 'NotAllowedError')
+    })
+    setExecCommand(() => true)
+
+    const { result } = renderHook(() => useClipboard({ successDuration: 20 }))
+
+    let copied = false
+    await act(async () => {
+      copied = await result.current.copy('hook copy')
+    })
+
+    expect(copied).toBe(true)
+    expect(result.current.copied).toBe(true)
+
+    await waitFor(() => {
+      expect(result.current.copied).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Centralize clipboard copying behind a shared fallback that uses the Clipboard API first and a textarea fallback when needed.
- Update copy actions in LDIF, SAML metadata, and shared hooks to report success only when copy actually succeeds.
- Improve accessibility and testability by adding explicit labels/IDs for switches and form fields.
- Expand e2e coverage for OAuth PKCE and add new coverage for UserInfo and SAML SP metadata flows.

## Testing
- Added unit tests for clipboard success, fallback, and failure behavior.
- Added Playwright e2e coverage for UserInfo and SAML SP metadata generation.
- Not run (not requested)