### PR TITLE
feat: Expand local IAM tools catalog and privacy controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A collection of specialized tools for Identity and Access Management (IAM) development and debugging. These tools help developers understand, troubleshoot, and work with various IAM technologies like JWT tokens, OIDC providers, and OAuth 2.0 flows.
 
+Most analysis tools run locally in the browser. Raw token history is disabled by default and can be enabled explicitly from Settings; avoid using production credentials in any debugging tool.
+
 ## Technologies
 
 - **Frontend**: Vite + React + TypeScript
@@ -242,6 +244,15 @@ Analyze and debug JWT tokens with detailed information about:
 
 See [Token Inspector Documentation](docs/feature-guides/token-inspector.md) for detailed usage instructions.
 
+### Token Claims Diff & Redirect URI Debugger
+
+Troubleshoot OAuth and OIDC integration drift locally:
+
+- Compare two JWTs with set-aware audience, scope, role, group, permission, and entitlement differences
+- Review issuer, subject, issuance, expiration, and lifetime changes
+- Compare requested redirect URIs against an exact registration allowlist
+- Detect fragments, wildcard registrations, unsafe transport, custom-scheme concerns, and native loopback port matches
+
 ### OIDC Explorer
 
 Explore and analyze OpenID Connect provider configurations:
@@ -281,9 +292,30 @@ Explore and validate LDAP data sets:
 
 - Schema Explorer for RFC/vendor schema parsing and visualization
 - LDIF Builder & Viewer with schema-based validation and templates
+- RFC 4515 filter parsing, formatting, explanation, URL encoding, and assertion-value escaping
 - Local-only storage for saved schema snapshots
 
 See [LDAP Tools Documentation](docs/feature-guides/ldap-suite.md) for details.
+
+### SCIM Tools
+
+Build and validate identity lifecycle payloads locally:
+
+- Validate SCIM 2.0 User, Group, and Enterprise User resource structure
+- Diagnose schema, required-field, type, extension, and multi-valued attribute problems
+- Compose canonical add, remove, and replace PatchOp documents
+- Validate existing SCIM PATCH JSON and attribute paths
+
+### TOTP Debugger
+
+Inspect MFA configuration without sending or retaining the shared secret:
+
+- Parse Base32 seeds and `otpauth://totp` URIs
+- Generate SHA-1, SHA-256, or SHA-512 codes for current and adjacent windows
+- Verify candidate codes and identify clock-step drift
+- Generate random non-production test secrets
+
+See [Local IAM Utilities Documentation](docs/feature-guides/local-iam-utilities.md) for Token Claims Diff, Redirect URI, SCIM, LDAP Filter, and TOTP details.
 
 ## Deployment
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -175,3 +175,4 @@ The demo token endpoints accept an optional `claims` JSON object; reserved stand
   - Compatibility mode (default): legacy unsigned payload encoding.
   - Strict mode (`DEMO_TOKEN_SIGNING_SECRET` set): HMAC-signed envelopes in `v1.<payload>.<sig>` format.
 - In strict mode, tampered or legacy-form auth codes/refresh tokens are rejected with OAuth errors (`invalid_grant` for token exchange).
+- Demo authorization redirects default to this app's exact `/oauth-playground/callback` URI (with localhost/127.0.0.1 cross-port support in local development). Additional exact callback URIs can be registered with the comma-separated `DEMO_REDIRECT_URIS` Worker variable.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,6 +35,10 @@ Feature modules are self-contained units that implement specific tools or functi
 - **Data**: Static data, constants, and configuration
 - **Types**: TypeScript types specific to the feature
 
+The user-facing catalog metadata is centralized in `src/config/tool-catalog.ts`. Homepage cards,
+sidebar navigation, and breadcrumb titles consume this registry so newly added tools remain
+consistent across discovery surfaces.
+
 ### 2. Core Infrastructure
 
 - **Components**: Reusable UI components shared across features
@@ -55,7 +59,7 @@ The application includes serverless backend functions:
 2. **Data Processing**: Components use hooks and utilities to process data
 3. **External Requests**: When needed, the application makes requests to external APIs via the CORS proxy
 4. **State Management**: State is managed locally within components using React's useState and useContext
-5. **Persistence**: Some data is persisted in localStorage using custom hooks
+5. **Persistence**: Some preferences, environments, and caches are persisted in localStorage using custom hooks. Raw token history is opt-in and disabled by default.
 
 ## Cloudflare Integration
 

--- a/docs/feature-guides/README.md
+++ b/docs/feature-guides/README.md
@@ -9,6 +9,7 @@ This directory contains detailed documentation for each feature in the IAM Tools
 - [OAuth Playground](./oauth-playground.md) - Documentation for the interactive OAuth 2.0 flow testing tool
 - [SAML Suite](./saml-suite.md) - Documentation for SAML tools: Response Decoder, Request Builder, Metadata Validator, SP Metadata
 - [LDAP Tools](./ldap-suite.md) - Documentation for LDAP Schema Explorer and LDIF Builder & Viewer
+- [Local IAM Utilities](./local-iam-utilities.md) - Token diff, redirect URI, SCIM, LDAP filter, and TOTP tools
 
 ## Adding New Feature Guides
 

--- a/docs/feature-guides/local-iam-utilities.md
+++ b/docs/feature-guides/local-iam-utilities.md
@@ -1,0 +1,91 @@
+# Local IAM Utilities
+
+These tools run entirely in the browser. They do not make network requests, persist pasted inputs, or place sensitive values in URLs.
+
+## Token Claims Diff
+
+Route: `/token-comparison`
+
+Compare two compact JWTs to identify:
+
+- Added, removed, changed, and unchanged header or payload paths
+- Set-aware differences for `aud`, `scope`, `scp`, `roles`, `groups`, `permissions`, and `entitlements`
+- Issuer, subject, audience, scope, issuance, expiration, and lifetime drift
+- Nested custom-claim changes
+
+The tool only decodes tokens. It does not verify signatures or prove that either token is trustworthy. Use Token Inspector for cryptographic verification and issuer/audience policy checks.
+
+## Redirect URI Debugger
+
+Route: `/oauth/redirect-uri`
+
+Compare one requested OAuth redirect URI against a line-separated registration allowlist. The debugger checks:
+
+- Exact string matching
+- Native-app loopback IP redirects with dynamic ports
+- Prohibited fragments and embedded credentials
+- HTTPS, insecure non-loopback HTTP, and custom URI schemes
+- Existing query retention
+- Normalized-but-not-exact values and wildcard registrations
+
+The tool never opens or contacts a redirect URI. Its checks follow the redirect endpoint rules in [OAuth 2.0](https://www.rfc-editor.org/rfc/rfc6749.html) and native-app guidance in [RFC 8252](https://www.rfc-editor.org/rfc/rfc8252.html).
+
+## SCIM Resource Validator
+
+Route: `/scim/resource-validator`
+
+Validate SCIM 2.0 User and Group resources with field-level JSON paths. Checks include:
+
+- Core User and Group schema declarations
+- Required `userName` and Group `displayName` attributes
+- Common scalar, complex, and multi-valued attribute types
+- At most one `primary: true` value per multi-valued attribute
+- Enterprise User and custom-extension declaration consistency
+- Common metadata shape and resource-type mismatches
+
+This is a structural validator based on [SCIM Core Schema RFC 7643](https://www.rfc-editor.org/rfc/rfc7643.html). A service provider can apply additional custom schemas, mutability rules, and policy.
+
+## SCIM PATCH Builder
+
+Route: `/scim/patch-builder`
+
+Build or validate SCIM PatchOp documents:
+
+- Compose `add`, `remove`, and `replace` operations
+- Validate filtered and schema-qualified attribute paths
+- Require paths and values according to operation semantics
+- Produce canonical `application/scim+json` request JSON
+- Inspect existing raw PatchOp documents
+
+PATCH behavior follows [SCIM Protocol RFC 7644](https://www.rfc-editor.org/rfc/rfc7644.html).
+
+## LDAP Filter Studio
+
+Route: `/ldap/filter-studio`
+
+Work with RFC 4515 LDAP search filters:
+
+- Parse nested AND, OR, and NOT expressions
+- Parse equality, presence, substring, ordering, and approximate comparisons
+- Produce compact and indented filters
+- Read a plain-language explanation and typed expression tree
+- Generate strict URL percent encoding
+- Escape untrusted assertion values to prevent filter injection
+
+Syntax validation follows [RFC 4515](https://www.rfc-editor.org/rfc/rfc4515.html). Whether an entry matches can still vary by directory schema and server matching rules.
+
+## TOTP Debugger
+
+Route: `/mfa/totp`
+
+Debug time-based one-time passwords with:
+
+- Strict Base32 parsing
+- `otpauth://totp` URI parsing
+- SHA-1, SHA-256, and SHA-512 HMAC algorithms
+- Six- or eight-digit codes and 30- or 60-second periods
+- Previous, current, and next time windows
+- Candidate-code verification with a configurable drift window
+- Cryptographically random test-secret generation
+
+The implementation is tested against all [RFC 6238](https://www.rfc-editor.org/rfc/rfc6238.html) Appendix B vectors. Secrets remain in memory only; prefer non-production seeds.

--- a/docs/feature-guides/token-inspector.md
+++ b/docs/feature-guides/token-inspector.md
@@ -75,6 +75,10 @@ The tool includes example tokens to demonstrate various scenarios:
 3. Token with standard OAuth claims
 4. Token with custom claims
 
+### Token History and Privacy
+
+Decoded tokens remain in the current page by default. Saving raw tokens to browser storage is disabled until you explicitly enable **Settings → Token History → On**. Previously saved entries can be removed with **Settings → Clear All Data**. Treat tokens as credentials and prefer non-production values when debugging.
+
 ## Implementation Details
 
 ### Key Components

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -13,7 +13,13 @@ This project uses a feature-based architecture to organize code. Each feature is
 │   │   ├── oauthPlayground/# OAuth flows, introspection, UserInfo
 │   │   ├── saml/           # SAML response, request, metadata tools
 │   │   ├── ldap/           # LDAP schema explorer and LDIF builder
+│   │   ├── ldap-filter/    # RFC 4515 filter parser and studio
+│   │   ├── scim/           # SCIM resource validation and PATCH tools
+│   │   ├── token-comparison/# JWT claims diff
+│   │   ├── redirect-uri/   # OAuth redirect URI debugger
+│   │   ├── totp/           # RFC 6238 TOTP debugger
 │   │   └── not-found/      # 404 route
+│   ├── config/             # Typed tool catalog and route metadata
 │   ├── components/         # Shared components
 │   │   ├── layout/         # Layout components
 │   │   ├── navigation/     # Navigation components

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -3,12 +3,18 @@ export const selectors = {
   nav: {
     home: '[data-testid="sidebar-nav-home"]',
     tokenInspector: '[data-testid="sidebar-nav-token-inspector"]',
+    tokenComparison: '[data-testid="sidebar-nav-token-comparison"]',
     oidcExplorer: '[data-testid="sidebar-nav-oidc-explorer"]',
+    redirectUriDebugger: '[data-testid="sidebar-nav-redirect-uri-debugger"]',
     oauthPlayground: '[data-testid="sidebar-nav-oauth-playground"]',
     authCodePkce: '[data-testid="sidebar-nav-oauth-auth-code"]',
     clientCredentials: '[data-testid="sidebar-nav-oauth-client-credentials"]',
     introspection: '[data-testid="sidebar-nav-oauth-introspection"]',
     userinfo: '[data-testid="sidebar-nav-oauth-userinfo"]',
+    scimResourceValidator: '[data-testid="sidebar-nav-scim-resource-validator"]',
+    scimPatchBuilder: '[data-testid="sidebar-nav-scim-patch-builder"]',
+    totpDebugger: '[data-testid="sidebar-nav-totp-debugger"]',
+    ldapFilterStudio: '[data-testid="sidebar-nav-ldap-filter-studio"]',
   },
 
   // Common buttons
@@ -23,8 +29,14 @@ export const selectors = {
   // Home cards
   home: {
     tokenInspector: '[data-testid="home-card-token-inspector"]',
+    tokenComparison: '[data-testid="home-card-token-comparison"]',
     oidcExplorer: '[data-testid="home-card-oidc-explorer"]',
     oauthPlayground: '[data-testid="home-card-oauth-playground"]',
+    redirectUriDebugger: '[data-testid="home-card-redirect-uri-debugger"]',
+    scimResourceValidator: '[data-testid="home-card-scim-resource-validator"]',
+    scimPatchBuilder: '[data-testid="home-card-scim-patch-builder"]',
+    totpDebugger: '[data-testid="home-card-totp-debugger"]',
+    ldapFilterStudio: '[data-testid="home-card-ldap-filter-studio"]',
   },
 
   // Token Inspector

--- a/e2e/tests/ldap-ldif-builder.e2e.ts
+++ b/e2e/tests/ldap-ldif-builder.e2e.ts
@@ -9,7 +9,7 @@ test.describe('LDAP LDIF Builder', () => {
 
   test('should display page title and description', async ({ page }) => {
     await expect(
-      page.locator('[data-slot="card-title"]:has-text("LDIF Builder & Viewer")')
+      page.getByRole('heading', { level: 1, name: 'LDIF Builder & Viewer' })
     ).toBeVisible()
     await expect(page.locator('text=Generate, inspect, and validate LDIF')).toBeVisible()
   })

--- a/e2e/tests/ldap-schema-explorer.e2e.ts
+++ b/e2e/tests/ldap-schema-explorer.e2e.ts
@@ -9,7 +9,7 @@ test.describe('LDAP Schema Explorer', () => {
 
   test('should display page title and description', async ({ page }) => {
     await expect(
-      page.locator('[data-slot="card-title"]:has-text("LDAP Schema Explorer")')
+      page.getByRole('heading', { level: 1, name: 'LDAP Schema Explorer' })
     ).toBeVisible()
     await expect(page.locator('text=Visualize LDAP schema definitions')).toBeVisible()
   })

--- a/e2e/tests/new-iam-tools.e2e.ts
+++ b/e2e/tests/new-iam-tools.e2e.ts
@@ -1,0 +1,77 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('New local-first IAM tools', () => {
+  test('compares example JWT claims', async ({ page }) => {
+    await page.goto('/token-comparison')
+    await page.getByTestId('token-comparison-example').click()
+
+    await expect(page.getByText('Claim differences', { exact: true })).toBeVisible()
+    await expect(page.getByText('authentication_method', { exact: true })).toBeVisible()
+  })
+
+  test('rejects a non-object JWT payload without crashing', async ({ page }) => {
+    await page.goto('/token-comparison')
+    await page.getByTestId('token-comparison-left').fill('e30.bnVsbA.signature')
+    await page.getByTestId('token-comparison-right').fill('e30.e30.signature')
+
+    await expect(
+      page.getByText('The JWT payload must be a JSON object.', { exact: true })
+    ).toBeVisible()
+    await expect(page.getByTestId('token-comparison-root')).toBeVisible()
+    await expect(page.getByText('Something went wrong.', { exact: true })).toHaveCount(0)
+  })
+
+  test('validates a SCIM User example', async ({ page }) => {
+    await page.goto('/scim/resource-validator')
+    await page.getByTestId('scim-resource-user-example').click()
+
+    await expect(page.getByText('Valid', { exact: true }).first()).toBeVisible()
+    await expect(page.getByText('User', { exact: true }).first()).toBeVisible()
+  })
+
+  test('builds and validates SCIM PATCH JSON', async ({ page }) => {
+    await page.goto('/scim/patch-builder')
+    await expect(page.getByText('Canonical PatchOp document', { exact: true })).toBeVisible()
+
+    await page.getByRole('tab', { name: 'Raw validator' }).click()
+    await page.getByTestId('scim-patch-example').click()
+    await expect(page.getByText('Valid PatchOp', { exact: true })).toBeVisible()
+  })
+
+  test('parses and explains an LDAP filter', async ({ page }) => {
+    await page.goto('/ldap/filter-studio')
+    await page.getByTestId('ldap-filter-example').click()
+
+    await expect(page.getByText('Valid', { exact: true })).toBeVisible()
+    await page.getByRole('tab', { name: 'Explanation' }).click()
+    await expect(page.getByText(/All of the following must match/)).toBeVisible()
+  })
+
+  test('generates and verifies a TOTP test code', async ({ page }) => {
+    await page.goto('/mfa/totp')
+    await page.getByTestId('totp-example').click()
+
+    const currentCode = page.getByTestId('totp-current-code')
+    await expect(currentCode).toHaveText(/^\d{6}$/)
+    await page.getByTestId('totp-candidate-code').fill((await currentCode.textContent()) ?? '')
+    await page.getByTestId('totp-verify').click()
+    await expect(page.getByText('Candidate verified', { exact: true })).toBeVisible()
+  })
+
+  test('checks a safe redirect registration', async ({ page }) => {
+    await page.goto('/oauth/redirect-uri')
+    await page.getByTestId('redirect-uri-example').click()
+
+    await expect(page.getByText('No blocking issue found', { exact: true })).toBeVisible()
+    await expect(page.getByText('Exact match', { exact: true }).first()).toBeVisible()
+  })
+
+  test('blocks an exact registration using an unsupported redirect scheme', async ({ page }) => {
+    await page.goto('/oauth/redirect-uri')
+    await page.getByTestId('redirect-uri-requested').fill('mailto:user@example.com')
+    await page.getByTestId('redirect-uri-registered').fill('mailto:user@example.com')
+
+    await expect(page.getByText('Redirect needs attention', { exact: true })).toBeVisible()
+    await expect(page.getByText('Unsupported redirect scheme', { exact: true })).toBeVisible()
+  })
+})

--- a/e2e/tests/routed-feature-smoke.e2e.ts
+++ b/e2e/tests/routed-feature-smoke.e2e.ts
@@ -2,6 +2,14 @@ import { expect, test } from '@playwright/test'
 
 const routedPages = [
   {
+    path: '/token-comparison',
+    heading: 'Token Claims Diff',
+  },
+  {
+    path: '/oauth/redirect-uri',
+    heading: 'Redirect URI Debugger',
+  },
+  {
     path: '/oauth-playground/client-credentials',
     heading: 'OAuth Client Credentials Flow',
   },
@@ -36,6 +44,22 @@ const routedPages = [
   {
     path: '/ldap/ldif-builder',
     heading: 'LDIF Builder & Viewer',
+  },
+  {
+    path: '/ldap/filter-studio',
+    heading: 'LDAP Filter Studio',
+  },
+  {
+    path: '/scim/resource-validator',
+    heading: 'SCIM Resource Validator',
+  },
+  {
+    path: '/scim/patch-builder',
+    heading: 'SCIM PATCH Builder',
+  },
+  {
+    path: '/mfa/totp',
+    heading: 'TOTP Debugger',
   },
   {
     path: '/not-a-real-tool',

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,22 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://iam.tools/</loc>
-    <lastmod>2025-04-10</lastmod> <changefreq>weekly</changefreq>
-    <priority>1.0</priority>
-  </url>
-  <url>
-    <loc>https://iam.tools/token-inspector</loc>
-    <lastmod>2025-04-10</lastmod> <changefreq>monthly</changefreq>
-    <priority>0.9</priority> </url>
-  <url>
-    <loc>https://iam.tools/oidc-explorer</loc> <lastmod>2025-04-10</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://iam.tools/oauth-playground</loc> <lastmod>2025-04-10</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  </urlset>
+  <url><loc>https://iam.tools/</loc><lastmod>2026-07-12</lastmod><changefreq>weekly</changefreq><priority>1.0</priority></url>
+  <url><loc>https://iam.tools/token-inspector</loc><lastmod>2026-07-12</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://iam.tools/token-comparison</loc><lastmod>2026-07-12</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://iam.tools/oidc-explorer</loc><lastmod>2026-07-12</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://iam.tools/oauth/redirect-uri</loc><lastmod>2026-07-12</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://iam.tools/oauth-playground</loc><lastmod>2026-07-12</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://iam.tools/oauth-playground/auth-code-pkce</loc><lastmod>2026-07-12</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://iam.tools/oauth-playground/client-credentials</loc><lastmod>2026-07-12</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://iam.tools/oauth-playground/introspection</loc><lastmod>2026-07-12</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://iam.tools/oauth-playground/userinfo</loc><lastmod>2026-07-12</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://iam.tools/scim/resource-validator</loc><lastmod>2026-07-12</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://iam.tools/scim/patch-builder</loc><lastmod>2026-07-12</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://iam.tools/mfa/totp</loc><lastmod>2026-07-12</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://iam.tools/saml/response-decoder</loc><lastmod>2026-07-12</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://iam.tools/saml/request-builder</loc><lastmod>2026-07-12</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://iam.tools/saml/metadata-validator</loc><lastmod>2026-07-12</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://iam.tools/saml/sp-metadata</loc><lastmod>2026-07-12</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://iam.tools/ldap/schema-explorer</loc><lastmod>2026-07-12</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://iam.tools/ldap/ldif-builder</loc><lastmod>2026-07-12</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://iam.tools/ldap/filter-studio</loc><lastmod>2026-07-12</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+</urlset>

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -12,24 +12,7 @@ import {
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb'
 import { useLocation, Link } from 'react-router-dom'
-
-// Route to human-readable title mapping
-const routeTitles: Record<string, string> = {
-  '/': 'Home',
-  '/token-inspector': 'Token Inspector',
-  '/oidc-explorer': 'OIDC Explorer',
-  '/oauth-playground': 'OAuth Playground',
-  '/oauth-playground/auth-code-pkce': 'Auth Code with PKCE',
-  '/oauth-playground/client-credentials': 'Client Credentials',
-  '/oauth-playground/introspection': 'Introspection',
-  '/oauth-playground/userinfo': 'UserInfo',
-  '/saml/response-decoder': 'SAML Response Decoder',
-  '/saml/request-builder': 'SAML Request Builder',
-  '/saml/metadata-validator': 'SAML Metadata Validator',
-  '/saml/sp-metadata': 'SP Metadata Generator',
-  '/ldap/schema-explorer': 'LDAP Schema Explorer',
-  '/ldap/ldif-builder': 'LDIF Builder',
-}
+import { routeTitles } from '@/config/tool-catalog'
 
 export function Layout() {
   const location = useLocation()

--- a/src/components/navigation/app-sidebar.tsx
+++ b/src/components/navigation/app-sidebar.tsx
@@ -1,24 +1,5 @@
 import * as React from 'react'
-import {
-  Fingerprint,
-  KeyRound,
-  Search,
-  SearchCheck,
-  FileJson,
-  ChevronRight,
-  FlaskConical,
-  UserRoundSearch,
-  Server,
-  UserRoundCheck,
-  Shield,
-  FileSearch,
-  Hammer,
-  BadgeCheck,
-  FileCog,
-  Database,
-  FileText,
-  FilePlus2,
-} from 'lucide-react'
+import { ChevronRight, Fingerprint } from 'lucide-react'
 import { Link } from 'react-router-dom'
 
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
@@ -26,6 +7,9 @@ import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
@@ -33,157 +17,39 @@ import {
   SidebarMenuSub,
   SidebarMenuSubButton,
   SidebarMenuSubItem,
-  SidebarGroup,
-  SidebarGroupLabel,
-  SidebarGroupContent,
 } from '@/components/ui/sidebar'
 import { NavSettings } from '@/components/navigation/nav-settings'
+import { toolCatalog, type ToolCatalogItem } from '@/config/tool-catalog'
 
-// Define tree structure for our menu
-const menuTree = [
-  {
-    title: 'OAuth/OIDC Tools',
-    icon: KeyRound,
-    items: [
-      {
-        title: 'Token Inspector',
-        url: '/token-inspector',
-        icon: Search,
-      },
-      {
-        title: 'OIDC Explorer',
-        url: '/oidc-explorer',
-        icon: FileJson,
-      },
-      {
-        title: 'OAuth Playground',
-        url: '/oauth-playground',
-        icon: FlaskConical,
-        items: [
-          {
-            title: 'Auth Code',
-            url: '/oauth-playground/auth-code-pkce',
-            icon: UserRoundCheck,
-          },
-          {
-            title: 'Client Credentials',
-            url: '/oauth-playground/client-credentials',
-            icon: Server,
-          },
-          {
-            title: 'Introspection',
-            url: '/oauth-playground/introspection',
-            icon: SearchCheck,
-          },
-          {
-            title: 'UserInfo',
-            url: '/oauth-playground/userinfo',
-            icon: UserRoundSearch,
-          },
-          // More flows will be added here later
-        ],
-      },
-    ],
-  },
-  {
-    title: 'SAML Tools',
-    icon: Shield,
-    items: [
-      {
-        title: 'Response Decoder',
-        url: '/saml/response-decoder',
-        icon: FileSearch,
-      },
-      {
-        title: 'Request Builder',
-        url: '/saml/request-builder',
-        icon: Hammer,
-      },
-      {
-        title: 'Metadata Validator',
-        url: '/saml/metadata-validator',
-        icon: BadgeCheck,
-      },
-      {
-        title: 'SP Metadata',
-        url: '/saml/sp-metadata',
-        icon: FileCog,
-      },
-    ],
-  },
-  {
-    title: 'LDAP Tools',
-    icon: Database,
-    items: [
-      {
-        title: 'Schema Explorer',
-        url: '/ldap/schema-explorer',
-        icon: FileText,
-      },
-      {
-        title: 'LDIF Builder',
-        url: '/ldap/ldif-builder',
-        icon: FilePlus2,
-      },
-    ],
-  },
-]
+function MenuTreeItem({ item }: { item: ToolCatalogItem }) {
+  const label = item.navigationTitle ?? item.title
 
-function getSidebarItemTestId(url?: string): string | undefined {
-  const mapping: Record<string, string> = {
-    '/': 'sidebar-nav-home',
-    '/token-inspector': 'sidebar-nav-token-inspector',
-    '/oidc-explorer': 'sidebar-nav-oidc-explorer',
-    '/oauth-playground': 'sidebar-nav-oauth-playground-root',
-    '/oauth-playground/auth-code-pkce': 'sidebar-nav-oauth-auth-code',
-    '/oauth-playground/client-credentials': 'sidebar-nav-oauth-client-credentials',
-    '/oauth-playground/introspection': 'sidebar-nav-oauth-introspection',
-    '/oauth-playground/userinfo': 'sidebar-nav-oauth-userinfo',
-    '/saml/response-decoder': 'sidebar-nav-saml-response-decoder',
-    '/saml/request-builder': 'sidebar-nav-saml-request-builder',
-    '/saml/metadata-validator': 'sidebar-nav-saml-metadata-validator',
-    '/saml/sp-metadata': 'sidebar-nav-saml-sp-metadata',
-    '/ldap/schema-explorer': 'sidebar-nav-ldap-schema-explorer',
-    '/ldap/ldif-builder': 'sidebar-nav-ldap-ldif-builder',
-  }
-
-  if (!url) return undefined
-  return mapping[url]
-}
-
-// Recursive component to render menu items
-function MenuTreeItem({ item }: { item: any }) {
-  // If it has subitems, render as collapsible
-  if (item.items && item.items.length) {
+  if (item.children?.length) {
     return (
       <SidebarMenuItem>
         <Collapsible
           className="group/collapsible w-full [&[data-state=open]>button>svg:first-child]:rotate-90"
-          defaultOpen={true}
+          defaultOpen
         >
           <CollapsibleTrigger asChild>
-            <SidebarMenuButton
-              data-testid={
-                item.url === '/oauth-playground' ? 'sidebar-nav-oauth-playground' : undefined
-              }
-            >
-              <ChevronRight className="transition-transform" />
-              <item.icon />
-              <span className="truncate">{item.title}</span>
+            <SidebarMenuButton data-testid={item.navigationTestId}>
+              <ChevronRight className="transition-transform" aria-hidden="true" />
+              <item.icon aria-hidden="true" />
+              <span className="truncate">{label}</span>
             </SidebarMenuButton>
           </CollapsibleTrigger>
           <CollapsibleContent>
             <SidebarMenuSub>
-              {item.items.map((subItem: any) => (
-                <React.Fragment key={subItem.url ?? subItem.title}>
-                  {subItem.items && subItem.items.length ? (
-                    <MenuTreeItem item={subItem} />
+              {item.children.map((child) => (
+                <React.Fragment key={child.id}>
+                  {child.children?.length ? (
+                    <MenuTreeItem item={child} />
                   ) : (
                     <SidebarMenuSubItem>
                       <SidebarMenuSubButton asChild>
-                        <Link to={subItem.url} data-testid={getSidebarItemTestId(subItem.url)}>
-                          {subItem.icon && <subItem.icon className="mr-2 size-4" />}
-                          <span className="truncate">{subItem.title}</span>
+                        <Link to={child.path} data-testid={child.navigationTestId}>
+                          <child.icon className="mr-2" aria-hidden="true" />
+                          <span className="truncate">{child.navigationTitle ?? child.title}</span>
                         </Link>
                       </SidebarMenuSubButton>
                     </SidebarMenuSubItem>
@@ -197,13 +63,12 @@ function MenuTreeItem({ item }: { item: any }) {
     )
   }
 
-  // If it's a leaf node without subitems
   return (
     <SidebarMenuItem>
       <SidebarMenuButton asChild>
-        <Link to={item.url} data-testid={getSidebarItemTestId(item.url)}>
-          <item.icon />
-          <span className="truncate">{item.title}</span>
+        <Link to={item.path} data-testid={item.navigationTestId}>
+          <item.icon aria-hidden="true" />
+          <span className="truncate">{label}</span>
         </Link>
       </SidebarMenuButton>
     </SidebarMenuItem>
@@ -218,8 +83,8 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
           <SidebarMenuItem>
             <SidebarMenuButton size="lg" asChild>
               <Link to="/" data-testid="sidebar-nav-home">
-                <div className="bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center rounded-lg">
-                  <Fingerprint className="size-4" />
+                <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground">
+                  <Fingerprint aria-hidden="true" />
                 </div>
                 <div className="grid flex-1 text-left text-sm leading-tight">
                   <span className="truncate font-medium">iam.tools</span>
@@ -231,13 +96,13 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         </SidebarMenu>
       </SidebarHeader>
       <SidebarContent>
-        {menuTree.map((section) => (
-          <SidebarGroup key={section.title}>
-            <SidebarGroupLabel>{section.title}</SidebarGroupLabel>
+        {toolCatalog.map((section) => (
+          <SidebarGroup key={section.id}>
+            <SidebarGroupLabel>{section.navigationTitle}</SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
-                {section.items.map((item) => (
-                  <MenuTreeItem key={item.url ?? item.title} item={item} />
+                {section.tools.map((item) => (
+                  <MenuTreeItem key={item.id} item={item} />
                 ))}
               </SidebarMenu>
             </SidebarGroupContent>

--- a/src/components/navigation/nav-settings.tsx
+++ b/src/components/navigation/nav-settings.tsx
@@ -12,6 +12,7 @@ import {
   Monitor,
   Trash,
   Save,
+  History,
   Activity,
 } from 'lucide-react'
 
@@ -42,6 +43,14 @@ import { oidcConfigCache } from '@/lib/cache/oidc-config-cache'
 import { jwksCache } from '@/lib/cache/jwks-cache'
 import { getDiagnosticsSnapshot, subscribeDiagnostics } from '@/lib/diagnostics/client-diagnostics'
 import { toast } from 'sonner'
+
+function formatMs(value?: number): string {
+  return typeof value === 'number' && Number.isFinite(value) ? `${Math.round(value)} ms` : '—'
+}
+
+function formatScore(value?: number): string {
+  return typeof value === 'number' && Number.isFinite(value) ? value.toFixed(3) : '—'
+}
 
 export function NavSettings() {
   const { isMobile } = useSidebar()
@@ -91,8 +100,7 @@ export function NavSettings() {
     if (typeof window === 'undefined' || !('performance' in window)) return
 
     const navEntry = performance.getEntriesByType('navigation')[0] as
-      | PerformanceNavigationTiming
-      | undefined
+      PerformanceNavigationTiming | undefined
     const paintEntries = performance.getEntriesByType('paint') as PerformanceEntry[]
     const fcpEntry = paintEntries.find((entry) => entry.name === 'first-contentful-paint')
 
@@ -151,11 +159,6 @@ export function NavSettings() {
 
   useEffect(() => subscribeDiagnostics(setDiagnostics), [])
 
-  const formatMs = (value?: number) =>
-    typeof value === 'number' && Number.isFinite(value) ? `${Math.round(value)} ms` : '—'
-  const formatScore = (value?: number) =>
-    typeof value === 'number' && Number.isFinite(value) ? value.toFixed(3) : '—'
-
   const performanceSummary = useMemo(
     () => ({
       ttfb: formatMs(perfMetrics?.ttfb),
@@ -185,6 +188,16 @@ export function NavSettings() {
     updateSettings({ maxHistoryItems: maxItems })
     toast.success('Settings updated', {
       description: `Maximum history items set to ${maxItems}.`,
+    })
+  }
+
+  const handleTokenHistoryChange = (value: string) => {
+    const persistTokenHistory = value === 'enabled'
+    updateSettings({ persistTokenHistory })
+    toast.success(persistTokenHistory ? 'Token history enabled' : 'Token history disabled', {
+      description: persistTokenHistory
+        ? 'Decoded tokens may now be saved in this browser.'
+        : 'Newly decoded tokens will not be saved in browser storage.',
     })
   }
 
@@ -257,6 +270,23 @@ export function NavSettings() {
             </DropdownMenuSub>
 
             {/* Storage Settings */}
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger className="flex items-center gap-2">
+                <History className="h-4 w-4" />
+                <span>Token History</span>
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                <DropdownMenuLabel>Save decoded tokens</DropdownMenuLabel>
+                <DropdownMenuRadioGroup
+                  value={settings.persistTokenHistory === true ? 'enabled' : 'disabled'}
+                  onValueChange={handleTokenHistoryChange}
+                >
+                  <DropdownMenuRadioItem value="disabled">Off (recommended)</DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="enabled">On</DropdownMenuRadioItem>
+                </DropdownMenuRadioGroup>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+
             <DropdownMenuSub>
               <DropdownMenuSubTrigger className="flex items-center gap-2">
                 <Save className="h-4 w-4" />

--- a/src/components/page/index.tsx
+++ b/src/components/page/index.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react'
-import { Card, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardDescription, CardHeader } from '@/components/ui/card'
 import { LucideIcon } from 'lucide-react'
 
 interface PageHeaderProps {
@@ -13,8 +13,8 @@ export function PageHeader({ title, description, icon: Icon }: PageHeaderProps) 
     <Card className="mb-6">
       <CardHeader className="pb-3">
         <div className="flex items-center gap-2">
-          {Icon && <Icon className="h-5 w-5 text-primary" />}
-          <CardTitle>{title}</CardTitle>
+          {Icon && <Icon className="h-5 w-5 text-primary" aria-hidden="true" />}
+          <h1 className="leading-none font-semibold">{title}</h1>
         </div>
         {description && <CardDescription className="text-sm">{description}</CardDescription>}
       </CardHeader>

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -53,8 +53,6 @@ function BreadcrumbPage({ className, ...props }: React.ComponentProps<'span'>) {
   return (
     <span
       data-slot="breadcrumb-page"
-      role="link"
-      aria-disabled="true"
       aria-current="page"
       className={cn('text-foreground font-normal', className)}
       {...props}

--- a/src/config/tool-catalog.ts
+++ b/src/config/tool-catalog.ts
@@ -1,0 +1,329 @@
+import type { LucideIcon } from 'lucide-react'
+import {
+  BadgeCheck,
+  Clock3,
+  Database,
+  FileCog,
+  FileJson,
+  FilePlus2,
+  FileSearch,
+  FileText,
+  FlaskConical,
+  GitCompareArrows,
+  Hammer,
+  KeyRound,
+  ListFilter,
+  ListPlus,
+  Route,
+  Search,
+  SearchCheck,
+  Server,
+  Shield,
+  UserCheck,
+  UserRoundCheck,
+  UserRoundSearch,
+  UsersRound,
+} from 'lucide-react'
+
+export interface ToolCatalogItem {
+  id: string
+  title: string
+  navigationTitle?: string
+  routeTitle?: string
+  description: string
+  path: string
+  icon: LucideIcon
+  tags: string[]
+  homeTestId?: string
+  navigationTestId?: string
+  showOnHome?: boolean
+  children?: ToolCatalogItem[]
+}
+
+export interface ToolCatalogSection {
+  id: string
+  title: string
+  navigationTitle: string
+  description: string
+  icon: LucideIcon
+  tools: ToolCatalogItem[]
+}
+
+export const toolCatalog: ToolCatalogSection[] = [
+  {
+    id: 'oauth-oidc',
+    title: 'OAuth/OIDC',
+    navigationTitle: 'OAuth/OIDC Tools',
+    description: 'Inspect tokens, provider metadata, redirects, and common OAuth flows.',
+    icon: KeyRound,
+    tools: [
+      {
+        id: 'token-inspector',
+        title: 'Token Inspector',
+        description: 'Decode JWTs, validate signatures, inspect claims, and load saved issuers.',
+        path: '/token-inspector',
+        icon: Search,
+        tags: ['JWT', 'JWKS'],
+        homeTestId: 'home-card-token-inspector',
+        navigationTestId: 'sidebar-nav-token-inspector',
+      },
+      {
+        id: 'token-comparison',
+        title: 'Token Claims Diff',
+        navigationTitle: 'Token Claims Diff',
+        routeTitle: 'Token Claims Diff',
+        description:
+          'Compare two JWTs to isolate claim, scope, role, audience, and lifetime drift.',
+        path: '/token-comparison',
+        icon: GitCompareArrows,
+        tags: ['JWT', 'Diff'],
+        homeTestId: 'home-card-token-comparison',
+        navigationTestId: 'sidebar-nav-token-comparison',
+      },
+      {
+        id: 'oidc-explorer',
+        title: 'OIDC Explorer',
+        description: 'Fetch discovery documents, inspect provider metadata, and review keys.',
+        path: '/oidc-explorer',
+        icon: FileJson,
+        tags: ['Discovery', 'Keys'],
+        homeTestId: 'home-card-oidc-explorer',
+        navigationTestId: 'sidebar-nav-oidc-explorer',
+      },
+      {
+        id: 'redirect-uri-debugger',
+        title: 'Redirect URI Debugger',
+        description:
+          'Compare registered and requested redirects with OAuth and native-app safety checks.',
+        path: '/oauth/redirect-uri',
+        icon: Route,
+        tags: ['OAuth', 'Redirects'],
+        homeTestId: 'home-card-redirect-uri-debugger',
+        navigationTestId: 'sidebar-nav-redirect-uri-debugger',
+      },
+      {
+        id: 'oauth-playground',
+        title: 'OAuth Playground',
+        description:
+          'Exercise auth code with PKCE, client credentials, introspection, and UserInfo.',
+        path: '/oauth-playground',
+        icon: FlaskConical,
+        tags: ['Flows', 'Demo IdP'],
+        homeTestId: 'home-card-oauth-playground',
+        navigationTestId: 'sidebar-nav-oauth-playground',
+        children: [
+          {
+            id: 'oauth-auth-code',
+            title: 'Authorization Code with PKCE',
+            navigationTitle: 'Auth Code',
+            routeTitle: 'Auth Code with PKCE',
+            description: 'Build and exercise an Authorization Code flow with PKCE.',
+            path: '/oauth-playground/auth-code-pkce',
+            icon: UserRoundCheck,
+            tags: ['OAuth', 'PKCE'],
+            navigationTestId: 'sidebar-nav-oauth-auth-code',
+            showOnHome: false,
+          },
+          {
+            id: 'oauth-client-credentials',
+            title: 'Client Credentials',
+            description: 'Exercise a machine-to-machine Client Credentials flow.',
+            path: '/oauth-playground/client-credentials',
+            icon: Server,
+            tags: ['OAuth', 'M2M'],
+            navigationTestId: 'sidebar-nav-oauth-client-credentials',
+            showOnHome: false,
+          },
+          {
+            id: 'oauth-introspection',
+            title: 'Token Introspection',
+            navigationTitle: 'Introspection',
+            routeTitle: 'Introspection',
+            description: 'Inspect active token state through RFC 7662.',
+            path: '/oauth-playground/introspection',
+            icon: SearchCheck,
+            tags: ['OAuth', 'RFC 7662'],
+            navigationTestId: 'sidebar-nav-oauth-introspection',
+            showOnHome: false,
+          },
+          {
+            id: 'oauth-userinfo',
+            title: 'UserInfo Endpoint',
+            navigationTitle: 'UserInfo',
+            routeTitle: 'UserInfo',
+            description: 'Call an OpenID Connect UserInfo endpoint.',
+            path: '/oauth-playground/userinfo',
+            icon: UserRoundSearch,
+            tags: ['OIDC', 'Claims'],
+            navigationTestId: 'sidebar-nav-oauth-userinfo',
+            showOnHome: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'scim',
+    title: 'Provisioning / SCIM',
+    navigationTitle: 'SCIM Tools',
+    description: 'Validate lifecycle resources and build standards-aligned partial updates.',
+    icon: UsersRound,
+    tools: [
+      {
+        id: 'scim-resource-validator',
+        title: 'SCIM Resource Validator',
+        description: 'Validate SCIM User and Group JSON with precise, local-only diagnostics.',
+        path: '/scim/resource-validator',
+        icon: UserCheck,
+        tags: ['SCIM 2.0', 'JSON'],
+        homeTestId: 'home-card-scim-resource-validator',
+        navigationTestId: 'sidebar-nav-scim-resource-validator',
+      },
+      {
+        id: 'scim-patch-builder',
+        title: 'SCIM PATCH Builder',
+        description: 'Compose and validate add, remove, and replace PatchOp payloads.',
+        path: '/scim/patch-builder',
+        icon: ListPlus,
+        tags: ['SCIM 2.0', 'PATCH'],
+        homeTestId: 'home-card-scim-patch-builder',
+        navigationTestId: 'sidebar-nav-scim-patch-builder',
+      },
+    ],
+  },
+  {
+    id: 'mfa',
+    title: 'MFA',
+    navigationTitle: 'MFA Tools',
+    description: 'Debug time-based one-time passwords without sending secrets anywhere.',
+    icon: Clock3,
+    tools: [
+      {
+        id: 'totp-debugger',
+        title: 'TOTP Debugger',
+        description: 'Parse otpauth URIs, generate test codes, and diagnose clock-window drift.',
+        path: '/mfa/totp',
+        icon: Clock3,
+        tags: ['TOTP', 'Local only'],
+        homeTestId: 'home-card-totp-debugger',
+        navigationTestId: 'sidebar-nav-totp-debugger',
+      },
+    ],
+  },
+  {
+    id: 'saml',
+    title: 'SAML',
+    navigationTitle: 'SAML Tools',
+    description: 'Decode responses, build AuthnRequests, and work with service-provider metadata.',
+    icon: Shield,
+    tools: [
+      {
+        id: 'saml-response-decoder',
+        title: 'Response Decoder',
+        routeTitle: 'SAML Response Decoder',
+        description: 'Decode SAML responses and inspect assertions, attributes, and status codes.',
+        path: '/saml/response-decoder',
+        icon: FileSearch,
+        tags: ['Response', 'Assertions'],
+        homeTestId: 'home-card-saml-response-decoder',
+        navigationTestId: 'sidebar-nav-saml-response-decoder',
+      },
+      {
+        id: 'saml-request-builder',
+        title: 'AuthnRequest Builder',
+        navigationTitle: 'Request Builder',
+        routeTitle: 'SAML Request Builder',
+        description: 'Craft HTTP-POST and HTTP-Redirect AuthnRequests with optional signing.',
+        path: '/saml/request-builder',
+        icon: Hammer,
+        tags: ['Request', 'Redirect'],
+        homeTestId: 'home-card-saml-request-builder',
+        navigationTestId: 'sidebar-nav-saml-request-builder',
+      },
+      {
+        id: 'saml-metadata-validator',
+        title: 'Metadata Validator',
+        routeTitle: 'SAML Metadata Validator',
+        description: 'Fetch or paste metadata XML, review roles, endpoints, and signatures.',
+        path: '/saml/metadata-validator',
+        icon: BadgeCheck,
+        tags: ['Metadata', 'Signatures'],
+        homeTestId: 'home-card-saml-metadata-validator',
+        navigationTestId: 'sidebar-nav-saml-metadata-validator',
+      },
+      {
+        id: 'saml-sp-metadata',
+        title: 'SP Metadata Generator',
+        navigationTitle: 'SP Metadata',
+        description: 'Generate SP metadata with ACS/SLO endpoints, NameID formats, and certs.',
+        path: '/saml/sp-metadata',
+        icon: FileCog,
+        tags: ['SP', 'XML'],
+        homeTestId: 'home-card-saml-sp-metadata',
+        navigationTestId: 'sidebar-nav-saml-sp-metadata',
+      },
+    ],
+  },
+  {
+    id: 'ldap',
+    title: 'LDAP',
+    navigationTitle: 'LDAP Tools',
+    description: 'Parse schemas, validate LDIF, and understand LDAP search filters locally.',
+    icon: Database,
+    tools: [
+      {
+        id: 'ldap-schema-explorer',
+        title: 'Schema Explorer',
+        routeTitle: 'LDAP Schema Explorer',
+        description: 'Paste attributeTypes/objectClasses LDIF and save schema snapshots.',
+        path: '/ldap/schema-explorer',
+        icon: FileText,
+        tags: ['Schema', 'Offline'],
+        homeTestId: 'home-card-ldap-schema-explorer',
+        navigationTestId: 'sidebar-nav-ldap-schema-explorer',
+      },
+      {
+        id: 'ldap-ldif-builder',
+        title: 'LDIF Builder & Viewer',
+        navigationTitle: 'LDIF Builder',
+        routeTitle: 'LDIF Builder',
+        description: 'Import or compose LDIF, apply templates, and validate entries.',
+        path: '/ldap/ldif-builder',
+        icon: FilePlus2,
+        tags: ['LDIF', 'Validation'],
+        homeTestId: 'home-card-ldap-ldif-builder',
+        navigationTestId: 'sidebar-nav-ldap-ldif-builder',
+      },
+      {
+        id: 'ldap-filter-studio',
+        title: 'LDAP Filter Studio',
+        description: 'Parse, format, explain, encode, and safely escape RFC 4515 filters.',
+        path: '/ldap/filter-studio',
+        icon: ListFilter,
+        tags: ['RFC 4515', 'Filters'],
+        homeTestId: 'home-card-ldap-filter-studio',
+        navigationTestId: 'sidebar-nav-ldap-filter-studio',
+      },
+    ],
+  },
+]
+
+function flattenTools(items: ToolCatalogItem[]): ToolCatalogItem[] {
+  return items.flatMap((item) => [item, ...(item.children ? flattenTools(item.children) : [])])
+}
+
+export const allTools = toolCatalog.flatMap((section) => flattenTools(section.tools))
+
+export const routeTitles: Record<string, string> = Object.fromEntries(
+  allTools.map((tool) => [tool.path, tool.routeTitle ?? tool.title])
+)
+
+export const featuredToolIds = [
+  'scim-resource-validator',
+  'token-comparison',
+  'totp-debugger',
+] as const
+
+export function getToolById(id: string): ToolCatalogItem | undefined {
+  return allTools.find((tool) => tool.id === id)
+}

--- a/src/features/home/index.tsx
+++ b/src/features/home/index.tsx
@@ -1,19 +1,5 @@
 import { Link } from 'react-router-dom'
-import {
-  BadgeCheck,
-  Database,
-  FileCog,
-  FileJson,
-  FilePlus2,
-  FileSearch,
-  FileText,
-  Hammer,
-  HomeIcon,
-  KeyRound,
-  Search,
-  Shield,
-} from 'lucide-react'
-import type { LucideIcon } from 'lucide-react'
+import { HomeIcon, KeyRound } from 'lucide-react'
 import { PageContainer, PageHeader } from '@/components/page'
 import { Badge } from '@/components/ui/badge'
 import {
@@ -24,136 +10,43 @@ import {
   ItemMedia,
   ItemTitle,
 } from '@/components/ui/item'
+import {
+  featuredToolIds,
+  getToolById,
+  toolCatalog,
+  type ToolCatalogItem,
+  type ToolCatalogSection,
+} from '@/config/tool-catalog'
 
-interface ToolDefinition {
-  title: string
-  description: string
-  to: string
-  icon: LucideIcon
-  testId: string
-  tags: string[]
-}
+const homeSections = toolCatalog.map((section) => ({
+  ...section,
+  tools: section.tools.filter((tool) => tool.showOnHome !== false),
+}))
 
-interface ToolSection {
-  title: string
-  description: string
-  icon: LucideIcon
-  tools: ToolDefinition[]
-}
+const featuredTools = featuredToolIds
+  .map((id) => getToolById(id))
+  .filter((tool): tool is ToolCatalogItem => Boolean(tool))
 
-const toolSections: ToolSection[] = [
-  {
-    title: 'OAuth/OIDC',
-    description: 'Inspect tokens, discovery metadata, JWKS, and common OAuth flows.',
-    icon: KeyRound,
-    tools: [
-      {
-        title: 'Token Inspector',
-        description: 'Decode JWTs, validate signatures, inspect claims, and load saved issuers.',
-        to: '/token-inspector',
-        icon: Search,
-        testId: 'home-card-token-inspector',
-        tags: ['JWT', 'JWKS'],
-      },
-      {
-        title: 'OIDC Explorer',
-        description: 'Fetch discovery documents, inspect provider metadata, and review keys.',
-        to: '/oidc-explorer',
-        icon: FileJson,
-        testId: 'home-card-oidc-explorer',
-        tags: ['Discovery', 'Keys'],
-      },
-      {
-        title: 'OAuth Playground',
-        description:
-          'Exercise auth code with PKCE, client credentials, introspection, and UserInfo.',
-        to: '/oauth-playground',
-        icon: KeyRound,
-        testId: 'home-card-oauth-playground',
-        tags: ['Flows', 'Demo IdP'],
-      },
-    ],
-  },
-  {
-    title: 'SAML',
-    description: 'Decode responses, build AuthnRequests, and work with service-provider metadata.',
-    icon: Shield,
-    tools: [
-      {
-        title: 'Response Decoder',
-        description: 'Decode SAML responses and inspect assertions, attributes, and status codes.',
-        to: '/saml/response-decoder',
-        icon: FileSearch,
-        testId: 'home-card-saml-response-decoder',
-        tags: ['Response', 'Assertions'],
-      },
-      {
-        title: 'AuthnRequest Builder',
-        description: 'Craft HTTP-POST and HTTP-Redirect AuthnRequests with optional signing.',
-        to: '/saml/request-builder',
-        icon: Hammer,
-        testId: 'home-card-saml-request-builder',
-        tags: ['Request', 'Redirect'],
-      },
-      {
-        title: 'Metadata Validator',
-        description: 'Fetch or paste metadata XML, review roles, endpoints, and signatures.',
-        to: '/saml/metadata-validator',
-        icon: BadgeCheck,
-        testId: 'home-card-saml-metadata-validator',
-        tags: ['Metadata', 'Signatures'],
-      },
-      {
-        title: 'SP Metadata Generator',
-        description: 'Generate SP metadata with ACS/SLO endpoints, NameID formats, and certs.',
-        to: '/saml/sp-metadata',
-        icon: FileCog,
-        testId: 'home-card-saml-sp-metadata',
-        tags: ['SP', 'XML'],
-      },
-    ],
-  },
-  {
-    title: 'LDAP',
-    description: 'Parse directory schemas and validate LDIF entries locally in the browser.',
-    icon: Database,
-    tools: [
-      {
-        title: 'Schema Explorer',
-        description: 'Paste attributeTypes/objectClasses LDIF and save schema snapshots.',
-        to: '/ldap/schema-explorer',
-        icon: FileText,
-        testId: 'home-card-ldap-schema-explorer',
-        tags: ['Schema', 'Offline'],
-      },
-      {
-        title: 'LDIF Builder & Viewer',
-        description: 'Import or compose LDIF, apply templates, and validate entries.',
-        to: '/ldap/ldif-builder',
-        icon: FilePlus2,
-        testId: 'home-card-ldap-ldif-builder',
-        tags: ['LDIF', 'Validation'],
-      },
-    ],
-  },
-]
+const totalToolCount = homeSections.reduce((count, section) => count + section.tools.length, 0)
 
-const featuredTools = [toolSections[0].tools[0], toolSections[0].tools[1], toolSections[2].tools[1]]
-
-const totalToolCount = toolSections.reduce((count, section) => count + section.tools.length, 0)
-
-function ToolCard({ tool, exposeTestId = true }: { tool: ToolDefinition; exposeTestId?: boolean }) {
+function ToolCard({
+  tool,
+  exposeTestId = true,
+}: {
+  tool: ToolCatalogItem
+  exposeTestId?: boolean
+}) {
   const Icon = tool.icon
 
   return (
     <Item asChild interactive className="h-full p-0">
       <Link
-        to={tool.to}
+        to={tool.path}
         className="flex h-full w-full items-start gap-4 p-4"
-        data-testid={exposeTestId ? tool.testId : undefined}
+        data-testid={exposeTestId ? tool.homeTestId : undefined}
       >
         <ItemMedia variant="icon" className="bg-primary/10 text-primary">
-          <Icon className="h-5 w-5" aria-hidden="true" />
+          <Icon className="size-5" aria-hidden="true" />
         </ItemMedia>
         <ItemContent className="min-w-0 gap-3">
           <div className="flex min-w-0 flex-col gap-1">
@@ -173,14 +66,14 @@ function ToolCard({ tool, exposeTestId = true }: { tool: ToolDefinition; exposeT
   )
 }
 
-function SectionHeader({ section }: { section: ToolSection }) {
+function SectionHeader({ section }: { section: ToolCatalogSection }) {
   const Icon = section.icon
 
   return (
     <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
       <div className="flex items-start gap-3">
-        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
-          <Icon className="h-5 w-5" aria-hidden="true" />
+        <span className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+          <Icon className="size-5" aria-hidden="true" />
         </span>
         <div className="min-w-0">
           <h2 className="text-xl font-semibold tracking-normal">{section.title}</h2>
@@ -207,30 +100,30 @@ export default function HomePage() {
         <section className="grid gap-3 lg:grid-cols-4">
           <Item className="h-full">
             <ItemMedia variant="icon" className="bg-primary text-primary-foreground">
-              <KeyRound className="h-5 w-5" aria-hidden="true" />
+              <KeyRound className="size-5" aria-hidden="true" />
             </ItemMedia>
             <ItemContent>
               <ItemTitle>{totalToolCount} local-first tools</ItemTitle>
               <ItemDescription>
-                Most workflows run in the browser, with proxy support only where identity endpoints
-                need it.
+                Sensitive inputs stay in this tab. Network access is only used by tools that
+                explicitly call identity endpoints.
               </ItemDescription>
             </ItemContent>
           </Item>
 
           <ItemGroup className="grid gap-3 sm:grid-cols-3 lg:col-span-3">
             {featuredTools.map((tool) => (
-              <ToolCard key={tool.to} tool={tool} exposeTestId={false} />
+              <ToolCard key={tool.path} tool={tool} exposeTestId={false} />
             ))}
           </ItemGroup>
         </section>
 
-        {toolSections.map((section) => (
-          <section key={section.title} className="flex flex-col gap-4">
+        {homeSections.map((section) => (
+          <section key={section.id} className="flex flex-col gap-4">
             <SectionHeader section={section} />
             <ItemGroup className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
               {section.tools.map((tool) => (
-                <ToolCard key={tool.to} tool={tool} />
+                <ToolCard key={tool.path} tool={tool} />
               ))}
             </ItemGroup>
           </section>

--- a/src/features/ldap-filter/pages/index.tsx
+++ b/src/features/ldap-filter/pages/index.tsx
@@ -1,0 +1,243 @@
+import { useMemo, useState } from 'react'
+import { Braces, ListFilter, ShieldCheck, Sparkles, Trash2 } from 'lucide-react'
+import { PageContainer, PageHeader } from '@/components/page'
+import { CopyButton, JsonDisplay } from '@/components/common'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from '@/components/ui/empty'
+import { Field, FieldDescription, FieldError, FieldGroup, FieldLabel } from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group'
+import { Item, ItemContent, ItemDescription, ItemGroup, ItemTitle } from '@/components/ui/item'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  encodeLdapFilterForUrl,
+  escapeLdapFilterValue,
+  explainLdapFilter,
+  formatLdapFilter,
+  validateLdapFilter,
+} from '@/features/ldap-filter/utils'
+
+const FILTER_EXAMPLE =
+  '(&\n  (objectClass=person)\n  (|(mail=*@example.com)(uid=jdoe))\n  (!(accountStatus=disabled))\n)'
+
+export default function LdapFilterStudioPage() {
+  const [filter, setFilter] = useState('')
+  const [assertionValue, setAssertionValue] = useState('alice*)(|(uid=*))')
+
+  const validation = useMemo(() => (filter.trim() ? validateLdapFilter(filter) : null), [filter])
+  const outputs = useMemo(() => {
+    if (!validation?.valid) return null
+    return {
+      compact: formatLdapFilter(validation.ast),
+      pretty: formatLdapFilter(validation.ast, true),
+      explanation: explainLdapFilter(validation.ast),
+      encoded: encodeLdapFilterForUrl(validation.ast),
+    }
+  }, [validation])
+  const escapedValue = useMemo(() => escapeLdapFilterValue(assertionValue), [assertionValue])
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="LDAP Filter Studio"
+        description="Parse, format, explain, URL-encode, and safely escape RFC 4515 LDAP search filters."
+        icon={ListFilter}
+      />
+
+      <div className="flex flex-col gap-6" data-testid="ldap-filter-studio-root">
+        <Alert>
+          <ShieldCheck />
+          <AlertTitle>Local syntax analysis</AlertTitle>
+          <AlertDescription>
+            Filters and assertion values stay in this tab. Actual matching can still vary with a
+            directory server&apos;s schema and matching rules.
+          </AlertDescription>
+        </Alert>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Filter expression</CardTitle>
+            <CardDescription>
+              Enter one complete LDAP filter, including its outer parentheses.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Field data-invalid={Boolean(validation && !validation.valid)}>
+              <FieldLabel htmlFor="ldap-filter-input">RFC 4515 filter</FieldLabel>
+              <Textarea
+                id="ldap-filter-input"
+                value={filter}
+                onChange={(event) => setFilter(event.target.value)}
+                placeholder="(&(objectClass=person)(mail=*@example.com))"
+                className="min-h-48 font-mono text-xs"
+                autoComplete="off"
+                spellCheck={false}
+                aria-invalid={Boolean(validation && !validation.valid)}
+                data-testid="ldap-filter-input"
+              />
+              <FieldDescription>
+                Supports AND, OR, NOT, equality, presence, substring, ordering, and approximate
+                filters. Extensible-match syntax is intentionally called out as unsupported.
+              </FieldDescription>
+              {validation && !validation.valid ? (
+                <FieldError>
+                  Line {validation.diagnostics[0].line}, column {validation.diagnostics[0].column}:{' '}
+                  {validation.diagnostics[0].message}
+                </FieldError>
+              ) : null}
+            </Field>
+          </CardContent>
+          <CardFooter className="flex-wrap gap-2">
+            <Button onClick={() => setFilter(FILTER_EXAMPLE)} data-testid="ldap-filter-example">
+              <Sparkles data-icon="inline-start" />
+              Load example
+            </Button>
+            <Button variant="ghost" onClick={() => setFilter('')} disabled={!filter}>
+              <Trash2 data-icon="inline-start" />
+              Clear
+            </Button>
+          </CardFooter>
+        </Card>
+
+        {validation?.valid && outputs ? (
+          <>
+            <ItemGroup className="grid gap-3 sm:grid-cols-3">
+              <Item>
+                <ItemContent>
+                  <ItemTitle>Syntax</ItemTitle>
+                  <ItemDescription>Complete filter parsed successfully</ItemDescription>
+                </ItemContent>
+                <Badge>Valid</Badge>
+              </Item>
+              <Item>
+                <ItemContent>
+                  <ItemTitle>Root operation</ItemTitle>
+                  <ItemDescription>Top-level AST node</ItemDescription>
+                </ItemContent>
+                <Badge variant="outline">{validation.ast.type}</Badge>
+              </Item>
+              <Item>
+                <ItemContent>
+                  <ItemTitle>URL encoding</ItemTitle>
+                  <ItemDescription>{outputs.encoded.length} characters</ItemDescription>
+                </ItemContent>
+                <CopyButton text={outputs.encoded} showText={false} />
+              </Item>
+            </ItemGroup>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Filter output</CardTitle>
+                <CardDescription>
+                  Switch between a formatted filter, plain-language reading, and the parsed tree.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Tabs defaultValue="formatted">
+                  <TabsList className="grid w-full grid-cols-3 sm:w-fit">
+                    <TabsTrigger value="formatted">Formatted</TabsTrigger>
+                    <TabsTrigger value="explanation">Explanation</TabsTrigger>
+                    <TabsTrigger value="ast">AST</TabsTrigger>
+                  </TabsList>
+                  <TabsContent value="formatted" className="flex flex-col gap-4 pt-3">
+                    <div className="flex flex-wrap justify-end gap-2">
+                      <CopyButton text={outputs.pretty} copiedText="Filter copied" />
+                    </div>
+                    <JsonDisplay data={outputs.pretty} language="text" showCopyButton={false} />
+                    <Field>
+                      <FieldLabel htmlFor="ldap-filter-url-encoded">URL-encoded value</FieldLabel>
+                      <Textarea
+                        id="ldap-filter-url-encoded"
+                        value={outputs.encoded}
+                        readOnly
+                        className="min-h-24 font-mono text-xs"
+                      />
+                      <FieldDescription>
+                        Use as the value of an LDAP URL&apos;s <code>filter</code> component or a
+                        percent-encoded query parameter.
+                      </FieldDescription>
+                    </Field>
+                  </TabsContent>
+                  <TabsContent value="explanation" className="pt-3">
+                    <JsonDisplay data={outputs.explanation} language="text" maxHeight="28rem" />
+                  </TabsContent>
+                  <TabsContent value="ast" className="pt-3">
+                    <JsonDisplay data={validation.ast} maxHeight="28rem" />
+                  </TabsContent>
+                </Tabs>
+              </CardContent>
+            </Card>
+          </>
+        ) : filter.trim() ? null : (
+          <Empty>
+            <EmptyMedia variant="icon">
+              <Braces />
+            </EmptyMedia>
+            <EmptyTitle>Enter an LDAP filter</EmptyTitle>
+            <EmptyDescription>
+              Load the nested example to see formatting, a human-readable explanation, an AST, and
+              strict URL encoding.
+            </EmptyDescription>
+          </Empty>
+        )}
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Assertion-value escaper</CardTitle>
+            <CardDescription>
+              Escape untrusted input before inserting it as a value in a programmatically built
+              filter. This prevents parentheses, asterisks, backslashes, and NUL bytes from changing
+              filter structure.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <FieldGroup className="grid gap-5 md:grid-cols-2">
+              <Field>
+                <FieldLabel htmlFor="ldap-assertion-value">Untrusted assertion value</FieldLabel>
+                <Input
+                  id="ldap-assertion-value"
+                  value={assertionValue}
+                  onChange={(event) => setAssertionValue(event.target.value)}
+                  autoComplete="off"
+                  spellCheck={false}
+                  data-testid="ldap-filter-escape-input"
+                />
+              </Field>
+              <Field>
+                <FieldLabel htmlFor="ldap-escaped-value">Escaped value</FieldLabel>
+                <InputGroup>
+                  <InputGroupInput
+                    id="ldap-escaped-value"
+                    value={escapedValue}
+                    readOnly
+                    className="font-mono text-xs"
+                    data-testid="ldap-filter-escaped-output"
+                  />
+                  <InputGroupAddon align="inline-end" className="p-0">
+                    <CopyButton
+                      text={escapedValue}
+                      showText={false}
+                      variant="ghost"
+                      className="rounded-none border-0 shadow-none"
+                    />
+                  </InputGroupAddon>
+                </InputGroup>
+              </Field>
+            </FieldGroup>
+          </CardContent>
+        </Card>
+      </div>
+    </PageContainer>
+  )
+}

--- a/src/features/ldap-filter/utils/index.ts
+++ b/src/features/ldap-filter/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './ldap-filter'

--- a/src/features/ldap-filter/utils/ldap-filter.ts
+++ b/src/features/ldap-filter/utils/ldap-filter.ts
@@ -1,0 +1,759 @@
+export interface LdapAndFilter {
+  type: 'and'
+  children: LdapFilterAst[]
+}
+
+export interface LdapOrFilter {
+  type: 'or'
+  children: LdapFilterAst[]
+}
+
+export interface LdapNotFilter {
+  type: 'not'
+  child: LdapFilterAst
+}
+
+export interface LdapEqualityFilter {
+  type: 'equality'
+  attribute: string
+  value: string
+}
+
+export interface LdapPresenceFilter {
+  type: 'presence'
+  attribute: string
+}
+
+export interface LdapSubstringFilter {
+  type: 'substring'
+  attribute: string
+  initial?: string
+  any: string[]
+  final?: string
+}
+
+export interface LdapGreaterOrEqualFilter {
+  type: 'greaterOrEqual'
+  attribute: string
+  value: string
+}
+
+export interface LdapLessOrEqualFilter {
+  type: 'lessOrEqual'
+  attribute: string
+  value: string
+}
+
+export interface LdapApproxFilter {
+  type: 'approx'
+  attribute: string
+  value: string
+}
+
+export type LdapFilterAst =
+  | LdapAndFilter
+  | LdapOrFilter
+  | LdapNotFilter
+  | LdapEqualityFilter
+  | LdapPresenceFilter
+  | LdapSubstringFilter
+  | LdapGreaterOrEqualFilter
+  | LdapLessOrEqualFilter
+  | LdapApproxFilter
+
+export interface LdapFilterDiagnostic {
+  /** Zero-based UTF-16 offset into the supplied filter string. */
+  position: number
+  /** One-based line number. */
+  line: number
+  /** One-based column number. */
+  column: number
+  message: string
+}
+
+export type LdapFilterValidationResult =
+  | {
+      valid: true
+      ast: LdapFilterAst
+      diagnostics: LdapFilterDiagnostic[]
+    }
+  | {
+      valid: false
+      ast: null
+      diagnostics: LdapFilterDiagnostic[]
+    }
+
+export class LdapFilterSyntaxError extends Error {
+  readonly position: number
+
+  constructor(message: string, position: number) {
+    super(message)
+    this.name = 'LdapFilterSyntaxError'
+    this.position = position
+  }
+}
+
+interface PositionedByte {
+  byte: number
+  position: number
+}
+
+interface RawSubstringSegment {
+  raw: string
+  offset: number
+}
+
+type AssertionOperator = '=' | '>=' | '<=' | '~='
+
+const HEX_PAIR = /^[0-9a-fA-F]{2}$/
+const ATTRIBUTE_DESCRIPTION =
+  /^(?:[A-Za-z][A-Za-z0-9-]*|[0-9]+(?:\.[0-9]+)+)(?:;[A-Za-z][A-Za-z0-9-]*)*$/
+
+function isHighSurrogate(codeUnit: number): boolean {
+  return codeUnit >= 0xd800 && codeUnit <= 0xdbff
+}
+
+function isLowSurrogate(codeUnit: number): boolean {
+  return codeUnit >= 0xdc00 && codeUnit <= 0xdfff
+}
+
+function appendCodePointBytes(codePoint: number, position: number, bytes: PositionedByte[]): void {
+  if (codePoint <= 0x7f) {
+    bytes.push({ byte: codePoint, position })
+    return
+  }
+
+  if (codePoint <= 0x7ff) {
+    bytes.push(
+      { byte: 0xc0 | (codePoint >> 6), position },
+      { byte: 0x80 | (codePoint & 0x3f), position }
+    )
+    return
+  }
+
+  if (codePoint <= 0xffff) {
+    bytes.push(
+      { byte: 0xe0 | (codePoint >> 12), position },
+      { byte: 0x80 | ((codePoint >> 6) & 0x3f), position },
+      { byte: 0x80 | (codePoint & 0x3f), position }
+    )
+    return
+  }
+
+  bytes.push(
+    { byte: 0xf0 | (codePoint >> 18), position },
+    { byte: 0x80 | ((codePoint >> 12) & 0x3f), position },
+    { byte: 0x80 | ((codePoint >> 6) & 0x3f), position },
+    { byte: 0x80 | (codePoint & 0x3f), position }
+  )
+}
+
+function decodePositionedUtf8(bytes: PositionedByte[]): string {
+  let result = ''
+
+  for (let index = 0; index < bytes.length;) {
+    const first = bytes[index]
+    if (first.byte <= 0x7f) {
+      result += String.fromCodePoint(first.byte)
+      index += 1
+      continue
+    }
+
+    let width: number
+    let codePoint: number
+    let minimum: number
+
+    if (first.byte >= 0xc2 && first.byte <= 0xdf) {
+      width = 2
+      codePoint = first.byte & 0x1f
+      minimum = 0x80
+    } else if (first.byte >= 0xe0 && first.byte <= 0xef) {
+      width = 3
+      codePoint = first.byte & 0x0f
+      minimum = 0x800
+    } else if (first.byte >= 0xf0 && first.byte <= 0xf4) {
+      width = 4
+      codePoint = first.byte & 0x07
+      minimum = 0x10000
+    } else {
+      throw new LdapFilterSyntaxError('Invalid UTF-8 byte in escaped value', first.position)
+    }
+
+    if (index + width > bytes.length) {
+      throw new LdapFilterSyntaxError('Incomplete UTF-8 sequence in escaped value', first.position)
+    }
+
+    for (let continuationIndex = 1; continuationIndex < width; continuationIndex += 1) {
+      const continuation = bytes[index + continuationIndex]
+      if ((continuation.byte & 0xc0) !== 0x80) {
+        throw new LdapFilterSyntaxError(
+          'Invalid UTF-8 continuation byte in escaped value',
+          continuation.position
+        )
+      }
+      codePoint = (codePoint << 6) | (continuation.byte & 0x3f)
+    }
+
+    if (
+      codePoint < minimum ||
+      codePoint > 0x10ffff ||
+      (codePoint >= 0xd800 && codePoint <= 0xdfff)
+    ) {
+      throw new LdapFilterSyntaxError('Invalid UTF-8 sequence in escaped value', first.position)
+    }
+
+    result += String.fromCodePoint(codePoint)
+    index += width
+  }
+
+  return result
+}
+
+function decodeFilterValue(value: string, basePosition: number): string {
+  const bytes: PositionedByte[] = []
+
+  for (let index = 0; index < value.length;) {
+    const codeUnit = value.charCodeAt(index)
+
+    if (value[index] === '\\') {
+      const pair = value.slice(index + 1, index + 3)
+      if (!HEX_PAIR.test(pair)) {
+        throw new LdapFilterSyntaxError(
+          'Escape sequences must contain exactly two hexadecimal digits',
+          basePosition + index
+        )
+      }
+      bytes.push({ byte: Number.parseInt(pair, 16), position: basePosition + index })
+      index += 3
+      continue
+    }
+
+    if (isHighSurrogate(codeUnit)) {
+      const nextCodeUnit = value.charCodeAt(index + 1)
+      if (!isLowSurrogate(nextCodeUnit)) {
+        throw new LdapFilterSyntaxError(
+          'Value contains an unpaired UTF-16 surrogate',
+          basePosition + index
+        )
+      }
+      const codePoint = 0x10000 + ((codeUnit - 0xd800) << 10) + (nextCodeUnit - 0xdc00)
+      appendCodePointBytes(codePoint, basePosition + index, bytes)
+      index += 2
+      continue
+    }
+
+    if (isLowSurrogate(codeUnit)) {
+      throw new LdapFilterSyntaxError(
+        'Value contains an unpaired UTF-16 surrogate',
+        basePosition + index
+      )
+    }
+
+    appendCodePointBytes(codeUnit, basePosition + index, bytes)
+    index += 1
+  }
+
+  return decodePositionedUtf8(bytes)
+}
+
+/** Escape an assertion value according to RFC 4515 valueencoding rules. */
+export function escapeLdapFilterValue(value: string): string {
+  let result = ''
+
+  for (let index = 0; index < value.length;) {
+    const codeUnit = value.charCodeAt(index)
+
+    if (isHighSurrogate(codeUnit)) {
+      const nextCodeUnit = value.charCodeAt(index + 1)
+      if (!isLowSurrogate(nextCodeUnit)) {
+        throw new LdapFilterSyntaxError('Value contains an unpaired UTF-16 surrogate', index)
+      }
+      result += value.slice(index, index + 2)
+      index += 2
+      continue
+    }
+
+    if (isLowSurrogate(codeUnit)) {
+      throw new LdapFilterSyntaxError('Value contains an unpaired UTF-16 surrogate', index)
+    }
+
+    switch (codeUnit) {
+      case 0x00:
+        result += '\\00'
+        break
+      case 0x28:
+        result += '\\28'
+        break
+      case 0x29:
+        result += '\\29'
+        break
+      case 0x2a:
+        result += '\\2a'
+        break
+      case 0x5c:
+        result += '\\5c'
+        break
+      default:
+        result += value[index]
+    }
+    index += 1
+  }
+
+  return result
+}
+
+/** Decode RFC 4515 hexadecimal octet escapes, including escaped UTF-8 sequences. */
+export function unescapeLdapFilterValue(value: string): string {
+  return decodeFilterValue(value, 0)
+}
+
+function findAssertionOperator(rawItem: string): {
+  operator: AssertionOperator
+  index: number
+} | null {
+  for (let index = 0; index < rawItem.length; index += 1) {
+    if (rawItem[index] === '\\') {
+      index += 2
+      continue
+    }
+
+    const pair = rawItem.slice(index, index + 2)
+    if (pair === '>=' || pair === '<=' || pair === '~=') {
+      return { operator: pair, index }
+    }
+    if (rawItem[index] === '=') {
+      return { operator: '=', index }
+    }
+  }
+
+  return null
+}
+
+function splitSubstringValue(rawValue: string): RawSubstringSegment[] {
+  const segments: RawSubstringSegment[] = []
+  let segmentStart = 0
+
+  for (let index = 0; index < rawValue.length; index += 1) {
+    if (rawValue[index] === '\\') {
+      index += 2
+      continue
+    }
+    if (rawValue[index] === '*') {
+      segments.push({ raw: rawValue.slice(segmentStart, index), offset: segmentStart })
+      segmentStart = index + 1
+    }
+  }
+
+  segments.push({ raw: rawValue.slice(segmentStart), offset: segmentStart })
+  return segments
+}
+
+function findUnescapedAsterisk(rawValue: string): number {
+  for (let index = 0; index < rawValue.length; index += 1) {
+    if (rawValue[index] === '\\') {
+      index += 2
+      continue
+    }
+    if (rawValue[index] === '*') {
+      return index
+    }
+  }
+  return -1
+}
+
+class FilterParser {
+  private position = 0
+
+  constructor(private readonly input: string) {}
+
+  parse(): LdapFilterAst {
+    this.skipWhitespace()
+    if (this.position >= this.input.length) {
+      this.fail('A filter expression is required')
+    }
+
+    const ast = this.parseFilter()
+    this.skipWhitespace()
+
+    if (this.position !== this.input.length) {
+      this.fail('Unexpected trailing input after the filter')
+    }
+
+    return ast
+  }
+
+  private parseFilter(): LdapFilterAst {
+    if (this.input[this.position] !== '(') {
+      this.fail('Expected "(" to start a filter')
+    }
+    this.position += 1
+
+    if (this.position >= this.input.length) {
+      this.fail('Unclosed filter; expected an expression and ")"')
+    }
+
+    const token = this.input[this.position]
+    if (token === '&' || token === '|') {
+      return this.parseFilterList(token)
+    }
+    if (token === '!') {
+      return this.parseNotFilter()
+    }
+
+    return this.parseItemFilter()
+  }
+
+  private parseFilterList(operator: '&' | '|'): LdapAndFilter | LdapOrFilter {
+    const operatorPosition = this.position
+    this.position += 1
+    this.skipWhitespace()
+
+    const children: LdapFilterAst[] = []
+    while (this.input[this.position] === '(') {
+      children.push(this.parseFilter())
+      this.skipWhitespace()
+    }
+
+    if (children.length === 0) {
+      this.fail(
+        `${operator === '&' ? 'AND' : 'OR'} filters require at least one child filter`,
+        operatorPosition
+      )
+    }
+
+    if (this.input[this.position] !== ')') {
+      this.fail('Expected another child filter or ")"')
+    }
+    this.position += 1
+
+    return operator === '&' ? { type: 'and', children } : { type: 'or', children }
+  }
+
+  private parseNotFilter(): LdapNotFilter {
+    const operatorPosition = this.position
+    this.position += 1
+    this.skipWhitespace()
+
+    if (this.input[this.position] !== '(') {
+      this.fail('NOT filters require exactly one child filter', operatorPosition)
+    }
+
+    const child = this.parseFilter()
+    this.skipWhitespace()
+
+    if (this.input[this.position] === '(') {
+      this.fail('NOT filters cannot contain more than one child filter')
+    }
+    if (this.input[this.position] !== ')') {
+      this.fail('Expected ")" after the NOT child filter')
+    }
+    this.position += 1
+
+    return { type: 'not', child }
+  }
+
+  private parseItemFilter(): LdapFilterAst {
+    const itemStart = this.position
+
+    while (this.position < this.input.length && this.input[this.position] !== ')') {
+      const character = this.input[this.position]
+      if (character === '(') {
+        this.fail('Unescaped "(" is not allowed in an assertion value')
+      }
+      if (character === '\0') {
+        this.fail('NUL bytes must be escaped as "\\00"')
+      }
+      if (character === '\\') {
+        const pair = this.input.slice(this.position + 1, this.position + 3)
+        if (!HEX_PAIR.test(pair)) {
+          this.fail('Escape sequences must contain exactly two hexadecimal digits')
+        }
+        this.position += 3
+        continue
+      }
+      this.position += 1
+    }
+
+    if (this.position >= this.input.length) {
+      this.fail('Unclosed filter; expected ")"')
+    }
+
+    const rawItem = this.input.slice(itemStart, this.position)
+    this.position += 1
+
+    const foundOperator = findAssertionOperator(rawItem)
+    if (!foundOperator) {
+      throw new LdapFilterSyntaxError(
+        'Expected one of "=", ">=", "<=", or "~=" in the filter item',
+        itemStart
+      )
+    }
+
+    const rawAttribute = rawItem.slice(0, foundOperator.index)
+    if (rawAttribute.includes(':')) {
+      throw new LdapFilterSyntaxError(
+        'Extensible match filters (":=") are not supported',
+        itemStart + rawAttribute.indexOf(':')
+      )
+    }
+    if (!ATTRIBUTE_DESCRIPTION.test(rawAttribute)) {
+      throw new LdapFilterSyntaxError(
+        `Invalid LDAP attribute description "${rawAttribute || '(empty)'}"`,
+        itemStart
+      )
+    }
+
+    const operatorLength = foundOperator.operator.length
+    const valueStart = itemStart + foundOperator.index + operatorLength
+    const rawValue = rawItem.slice(foundOperator.index + operatorLength)
+
+    if (foundOperator.operator === '=') {
+      return this.parseEqualityLikeFilter(rawAttribute, rawValue, valueStart)
+    }
+
+    const wildcardPosition = findUnescapedAsterisk(rawValue)
+    if (wildcardPosition !== -1) {
+      throw new LdapFilterSyntaxError(
+        'Asterisks in comparison values must be escaped as "\\2a"',
+        valueStart + wildcardPosition
+      )
+    }
+
+    const value = decodeFilterValue(rawValue, valueStart)
+    if (foundOperator.operator === '>=') {
+      return { type: 'greaterOrEqual', attribute: rawAttribute, value }
+    }
+    if (foundOperator.operator === '<=') {
+      return { type: 'lessOrEqual', attribute: rawAttribute, value }
+    }
+    return { type: 'approx', attribute: rawAttribute, value }
+  }
+
+  private parseEqualityLikeFilter(
+    attribute: string,
+    rawValue: string,
+    valueStart: number
+  ): LdapEqualityFilter | LdapPresenceFilter | LdapSubstringFilter {
+    const segments = splitSubstringValue(rawValue)
+    if (segments.length === 1) {
+      return {
+        type: 'equality',
+        attribute,
+        value: decodeFilterValue(rawValue, valueStart),
+      }
+    }
+
+    if (rawValue === '*') {
+      return { type: 'presence', attribute }
+    }
+
+    const first = segments[0]
+    const last = segments[segments.length - 1]
+    const middle = segments.slice(1, -1)
+
+    return {
+      type: 'substring',
+      attribute,
+      initial:
+        first.raw.length > 0 ? decodeFilterValue(first.raw, valueStart + first.offset) : undefined,
+      any: middle.map((segment) => decodeFilterValue(segment.raw, valueStart + segment.offset)),
+      final:
+        last.raw.length > 0 ? decodeFilterValue(last.raw, valueStart + last.offset) : undefined,
+    }
+  }
+
+  private skipWhitespace(): void {
+    while (/\s/u.test(this.input[this.position] ?? '')) {
+      this.position += 1
+    }
+  }
+
+  private fail(message: string, position = this.position): never {
+    throw new LdapFilterSyntaxError(message, position)
+  }
+}
+
+/** Parse one complete RFC 4515 LDAP filter string into a typed AST. */
+export function parseLdapFilter(input: string): LdapFilterAst {
+  return new FilterParser(input).parse()
+}
+
+function assertAttributeDescription(attribute: string): void {
+  if (!ATTRIBUTE_DESCRIPTION.test(attribute)) {
+    throw new TypeError(`Invalid LDAP attribute description "${attribute}"`)
+  }
+}
+
+function formatSubstringValue(filter: LdapSubstringFilter): string {
+  let value = filter.initial === undefined ? '' : escapeLdapFilterValue(filter.initial)
+  value += '*'
+  for (const segment of filter.any) {
+    value += `${escapeLdapFilterValue(segment)}*`
+  }
+  if (filter.final !== undefined) {
+    value += escapeLdapFilterValue(filter.final)
+  }
+  return value
+}
+
+function formatFilterNode(ast: LdapFilterAst, pretty: boolean, depth: number): string {
+  const indent = '  '.repeat(depth)
+  const childIndent = '  '.repeat(depth + 1)
+
+  switch (ast.type) {
+    case 'and':
+    case 'or': {
+      if (ast.children.length === 0) {
+        throw new TypeError(`${ast.type.toUpperCase()} filters require at least one child`)
+      }
+      const operator = ast.type === 'and' ? '&' : '|'
+      if (!pretty) {
+        return `(${operator}${ast.children
+          .map((child) => formatFilterNode(child, false, depth + 1))
+          .join('')})`
+      }
+      const children = ast.children
+        .map((child) => `${childIndent}${formatFilterNode(child, true, depth + 1)}`)
+        .join('\n')
+      return `(${operator}\n${children}\n${indent})`
+    }
+    case 'not':
+      if (!pretty) {
+        return `(!${formatFilterNode(ast.child, false, depth + 1)})`
+      }
+      return `(!\n${childIndent}${formatFilterNode(ast.child, true, depth + 1)}\n${indent})`
+    case 'equality':
+      assertAttributeDescription(ast.attribute)
+      return `(${ast.attribute}=${escapeLdapFilterValue(ast.value)})`
+    case 'presence':
+      assertAttributeDescription(ast.attribute)
+      return `(${ast.attribute}=*)`
+    case 'substring':
+      assertAttributeDescription(ast.attribute)
+      return `(${ast.attribute}=${formatSubstringValue(ast)})`
+    case 'greaterOrEqual':
+      assertAttributeDescription(ast.attribute)
+      return `(${ast.attribute}>=${escapeLdapFilterValue(ast.value)})`
+    case 'lessOrEqual':
+      assertAttributeDescription(ast.attribute)
+      return `(${ast.attribute}<=${escapeLdapFilterValue(ast.value)})`
+    case 'approx':
+      assertAttributeDescription(ast.attribute)
+      return `(${ast.attribute}~=${escapeLdapFilterValue(ast.value)})`
+  }
+}
+
+/** Format an AST as a compact filter or as an indented, parseable filter. */
+export function formatLdapFilter(ast: LdapFilterAst, pretty = false): string {
+  return formatFilterNode(ast, pretty, 0)
+}
+
+function quote(value: string): string {
+  return JSON.stringify(value)
+}
+
+function leafExplanation(
+  ast: Exclude<LdapFilterAst, LdapAndFilter | LdapOrFilter | LdapNotFilter>
+): string {
+  switch (ast.type) {
+    case 'equality':
+      return `${ast.attribute} equals ${quote(ast.value)}`
+    case 'presence':
+      return `${ast.attribute} is present`
+    case 'substring':
+      return `${ast.attribute} matches substring pattern ${quote(formatSubstringValue(ast))}`
+    case 'greaterOrEqual':
+      return `${ast.attribute} is greater than or equal to ${quote(ast.value)}`
+    case 'lessOrEqual':
+      return `${ast.attribute} is less than or equal to ${quote(ast.value)}`
+    case 'approx':
+      return `${ast.attribute} approximately equals ${quote(ast.value)}`
+  }
+}
+
+function explainFilterNode(ast: LdapFilterAst, depth: number): string[] {
+  const indent = '  '.repeat(depth)
+
+  if (ast.type !== 'and' && ast.type !== 'or' && ast.type !== 'not') {
+    return [`${indent}${leafExplanation(ast)}`]
+  }
+
+  const label =
+    ast.type === 'and'
+      ? 'All of the following must match'
+      : ast.type === 'or'
+        ? 'Any of the following may match'
+        : 'The following must not match'
+  const children = ast.type === 'not' ? [ast.child] : ast.children
+  const lines = [`${indent}${label}:`]
+
+  for (const child of children) {
+    const childLines = explainFilterNode(child, depth + 1)
+    const childIndent = '  '.repeat(depth + 1)
+    lines.push(`${childIndent}- ${childLines[0].trimStart()}`)
+    for (const continuation of childLines.slice(1)) {
+      lines.push(`${childIndent}  ${continuation.trimStart()}`)
+    }
+  }
+
+  return lines
+}
+
+/** Produce a plain-language, multi-line explanation of a filter AST. */
+export function explainLdapFilter(ast: LdapFilterAst): string {
+  return explainFilterNode(ast, 0).join('\n')
+}
+
+function diagnosticLocation(
+  input: string,
+  position: number
+): Pick<LdapFilterDiagnostic, 'line' | 'column'> {
+  const safePosition = Math.max(0, Math.min(position, input.length))
+  const prefix = input.slice(0, safePosition)
+  const lines = prefix.split(/\r\n|\r|\n/u)
+  return {
+    line: lines.length,
+    column: (lines[lines.length - 1]?.length ?? 0) + 1,
+  }
+}
+
+/** Validate without throwing and return an AST or a position-aware diagnostic. */
+export function validateLdapFilter(input: string): LdapFilterValidationResult {
+  try {
+    return { valid: true, ast: parseLdapFilter(input), diagnostics: [] }
+  } catch (error) {
+    const syntaxError =
+      error instanceof LdapFilterSyntaxError
+        ? error
+        : new LdapFilterSyntaxError(
+            error instanceof Error ? error.message : 'Unable to parse LDAP filter',
+            0
+          )
+    const location = diagnosticLocation(input, syntaxError.position)
+    return {
+      valid: false,
+      ast: null,
+      diagnostics: [
+        {
+          position: syntaxError.position,
+          line: location.line,
+          column: location.column,
+          message: syntaxError.message,
+        },
+      ],
+    }
+  }
+}
+
+/** Percent-encode a validated filter for use as a URL query value. */
+export function encodeLdapFilterForUrl(filter: LdapFilterAst | string): string {
+  const normalized =
+    typeof filter === 'string'
+      ? formatLdapFilter(parseLdapFilter(filter), false)
+      : formatLdapFilter(filter, false)
+
+  return encodeURIComponent(normalized).replace(
+    /[!'()*]/g,
+    (character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`
+  )
+}

--- a/src/features/oauthPlayground/pages/demo-auth.tsx
+++ b/src/features/oauthPlayground/pages/demo-auth.tsx
@@ -14,6 +14,7 @@ import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { getIssuerBaseUrl } from '@/lib/jwt/generate-signed-token'
+import { isAllowedDemoRedirectUri } from '../utils/demo-redirect'
 
 export function DemoAuthPage() {
   const [searchParams] = useSearchParams()
@@ -25,6 +26,9 @@ export function DemoAuthPage() {
   const scope = searchParams.get('scope') || ''
   const codeChallenge = searchParams.get('code_challenge') || ''
   const codeChallengeMethod = searchParams.get('code_challenge_method') || ''
+  const redirectAllowed = redirectUri
+    ? isAllowedDemoRedirectUri(redirectUri, window.location.href)
+    : false
 
   // Form state
   const [username, setUsername] = useState('demo-user')
@@ -32,11 +36,13 @@ export function DemoAuthPage() {
     ? 'Missing client_id parameter'
     : !redirectUri
       ? 'Missing redirect_uri parameter'
-      : !codeChallenge
-        ? 'Missing code_challenge parameter'
-        : codeChallengeMethod !== 'S256'
-          ? 'Unsupported code_challenge_method. Only S256 is supported.'
-          : null
+      : !redirectAllowed
+        ? 'The redirect_uri is not registered for this demo provider.'
+        : !codeChallenge
+          ? 'Missing code_challenge parameter'
+          : codeChallengeMethod !== 'S256'
+            ? 'Unsupported code_challenge_method. Only S256 is supported.'
+            : null
 
   // Handle login
   const handleLogin = () => {
@@ -70,6 +76,8 @@ export function DemoAuthPage() {
 
   // Handle deny
   const handleDeny = () => {
+    if (error) return
+
     // Construct the redirect URL with the error
     const redirectUrl = new URL(redirectUri)
     redirectUrl.searchParams.set('error', 'access_denied')

--- a/src/features/oauthPlayground/utils/demo-redirect.ts
+++ b/src/features/oauthPlayground/utils/demo-redirect.ts
@@ -1,0 +1,49 @@
+export const DEMO_CALLBACK_PATH = '/oauth-playground/callback'
+
+function isLocalHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase()
+  return (
+    normalized === 'localhost' ||
+    normalized === '127.0.0.1' ||
+    normalized === '[::1]' ||
+    normalized === '::1'
+  )
+}
+
+/**
+ * Demo OAuth redirects are intentionally narrower than production OAuth client
+ * registrations. By default, only this app's own callback is accepted. Exact
+ * additional callbacks can be supplied by the Worker environment.
+ */
+export function isAllowedDemoRedirectUri(
+  redirectUri: string,
+  appUrl: string,
+  configuredRedirectUris: readonly string[] = []
+): boolean {
+  let target: URL
+  let app: URL
+
+  try {
+    target = new URL(redirectUri)
+    app = new URL(appUrl)
+  } catch {
+    return false
+  }
+
+  if (!['http:', 'https:'].includes(target.protocol)) return false
+  if (target.username || target.password || target.hash) return false
+
+  if (configuredRedirectUris.some((configured) => configured.trim() === redirectUri)) {
+    return true
+  }
+
+  if (target.pathname !== DEMO_CALLBACK_PATH || target.search) {
+    return false
+  }
+
+  if (isLocalHostname(app.hostname)) {
+    return isLocalHostname(target.hostname)
+  }
+
+  return target.origin === app.origin
+}

--- a/src/features/redirect-uri/pages/index.tsx
+++ b/src/features/redirect-uri/pages/index.tsx
@@ -1,0 +1,345 @@
+import { useMemo, useState } from 'react'
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Info,
+  Route,
+  ShieldCheck,
+  Sparkles,
+  Trash2,
+  XCircle,
+} from 'lucide-react'
+import { PageContainer, PageHeader } from '@/components/page'
+import { CopyButton } from '@/components/common'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from '@/components/ui/empty'
+import { Field, FieldDescription, FieldGroup, FieldLabel } from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
+import {
+  Item,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemMedia,
+  ItemTitle,
+} from '@/components/ui/item'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  analyzeRedirectUri,
+  type RedirectFinding,
+  type RedirectFindingLevel,
+  type RedirectMatchType,
+} from '../utils/redirect-uri'
+
+const FINDING_ICON = {
+  pass: CheckCircle2,
+  error: XCircle,
+  warning: AlertTriangle,
+  info: Info,
+} satisfies Record<RedirectFindingLevel, typeof Info>
+
+const FINDING_VARIANT: Record<
+  RedirectFindingLevel,
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  pass: 'default',
+  error: 'destructive',
+  warning: 'secondary',
+  info: 'outline',
+}
+
+const MATCH_LABEL: Record<RedirectMatchType, string> = {
+  exact: 'Exact match',
+  'loopback-port': 'Loopback port match',
+  'normalized-only': 'Normalized only',
+  none: 'No match',
+  invalid: 'Invalid',
+}
+
+function FindingItem({ finding }: { finding: RedirectFinding }) {
+  const Icon = FINDING_ICON[finding.level]
+
+  return (
+    <Item>
+      <ItemMedia variant="icon">
+        <Icon aria-hidden="true" />
+      </ItemMedia>
+      <ItemContent>
+        <div className="flex flex-wrap items-center gap-2">
+          <ItemTitle>{finding.title}</ItemTitle>
+          <Badge variant={FINDING_VARIANT[finding.level]}>{finding.level}</Badge>
+        </div>
+        <ItemDescription>{finding.message}</ItemDescription>
+      </ItemContent>
+    </Item>
+  )
+}
+
+export default function RedirectUriDebuggerPage() {
+  const [requestedUri, setRequestedUri] = useState('')
+  const [registeredUris, setRegisteredUris] = useState('')
+
+  const analysis = useMemo(
+    () => (requestedUri.trim() ? analyzeRedirectUri(requestedUri, registeredUris) : null),
+    [registeredUris, requestedUri]
+  )
+  const report = useMemo(() => (analysis ? JSON.stringify(analysis, null, 2) : ''), [analysis])
+
+  const loadExample = () => {
+    setRequestedUri('https://app.example.com/oauth/callback?tenant=acme')
+    setRegisteredUris(
+      [
+        'https://app.example.com/oauth/callback?tenant=acme',
+        'https://staging.example.com/oauth/callback',
+        'http://127.0.0.1:49152/oauth/callback',
+      ].join('\n')
+    )
+  }
+
+  const clear = () => {
+    setRequestedUri('')
+    setRegisteredUris('')
+  }
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Redirect URI Debugger"
+        description="Explain redirect matching failures and catch unsafe OAuth client registrations before deployment."
+        icon={Route}
+      />
+
+      <div className="flex flex-col gap-6" data-testid="redirect-uri-debugger-root">
+        <Alert>
+          <ShieldCheck />
+          <AlertTitle>Analysis only</AlertTitle>
+          <AlertDescription>
+            This tool never opens the redirect, sends an authorization response, or contacts the
+            listed hosts. It compares strings and URI components locally.
+          </AlertDescription>
+        </Alert>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Redirect under test</CardTitle>
+            <CardDescription>
+              Paste the requested value and the client&apos;s registered allowlist exactly as
+              stored.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <FieldGroup>
+              <Field>
+                <FieldLabel htmlFor="redirect-uri-requested">Requested redirect URI</FieldLabel>
+                <Input
+                  id="redirect-uri-requested"
+                  value={requestedUri}
+                  onChange={(event) => setRequestedUri(event.target.value)}
+                  placeholder="https://app.example.com/oauth/callback"
+                  autoComplete="off"
+                  spellCheck={false}
+                  data-testid="redirect-uri-requested"
+                />
+                <FieldDescription>
+                  The exact <code>redirect_uri</code> carried by the authorization request.
+                </FieldDescription>
+              </Field>
+
+              <Field>
+                <FieldLabel htmlFor="redirect-uri-registered">Registered redirect URIs</FieldLabel>
+                <Textarea
+                  id="redirect-uri-registered"
+                  value={registeredUris}
+                  onChange={(event) => setRegisteredUris(event.target.value)}
+                  placeholder={
+                    'https://app.example.com/oauth/callback\ncom.example.app:/oauth/callback'
+                  }
+                  className="min-h-32 font-mono text-xs"
+                  autoComplete="off"
+                  spellCheck={false}
+                  data-testid="redirect-uri-registered"
+                />
+                <FieldDescription>
+                  One absolute URI per line. Empty lines are ignored.
+                </FieldDescription>
+              </Field>
+            </FieldGroup>
+          </CardContent>
+          <CardFooter className="flex-wrap gap-2">
+            <Button onClick={loadExample} data-testid="redirect-uri-example">
+              <Sparkles data-icon="inline-start" />
+              Load safe example
+            </Button>
+            <Button variant="ghost" onClick={clear} disabled={!requestedUri && !registeredUris}>
+              <Trash2 data-icon="inline-start" />
+              Clear
+            </Button>
+          </CardFooter>
+        </Card>
+
+        {analysis ? (
+          <>
+            <Card>
+              <CardHeader>
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="flex flex-col gap-1.5">
+                    <CardTitle>
+                      {analysis.safeToSend ? 'No blocking issue found' : 'Redirect needs attention'}
+                    </CardTitle>
+                    <CardDescription>
+                      {analysis.matchedRegistration
+                        ? `Matched registration: ${analysis.matchedRegistration}`
+                        : 'No acceptable registration match was found.'}
+                    </CardDescription>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <Badge variant={analysis.safeToSend ? 'default' : 'destructive'}>
+                      {MATCH_LABEL[analysis.matchType]}
+                    </Badge>
+                    <CopyButton text={report} copiedText="Report copied" />
+                  </div>
+                </div>
+              </CardHeader>
+              {analysis.parsed ? (
+                <CardContent>
+                  <ItemGroup className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                    <Item>
+                      <ItemContent>
+                        <ItemTitle>Scheme</ItemTitle>
+                        <ItemDescription>{analysis.parsed.scheme}</ItemDescription>
+                      </ItemContent>
+                    </Item>
+                    <Item>
+                      <ItemContent>
+                        <ItemTitle>Host</ItemTitle>
+                        <ItemDescription className="break-all">
+                          {analysis.parsed.host || 'No host'}
+                        </ItemDescription>
+                      </ItemContent>
+                    </Item>
+                    <Item>
+                      <ItemContent>
+                        <ItemTitle>Path</ItemTitle>
+                        <ItemDescription className="break-all">
+                          {analysis.parsed.path}
+                        </ItemDescription>
+                      </ItemContent>
+                    </Item>
+                    <Item>
+                      <ItemContent>
+                        <ItemTitle>Query</ItemTitle>
+                        <ItemDescription className="break-all">
+                          {analysis.parsed.query || 'None'}
+                        </ItemDescription>
+                      </ItemContent>
+                    </Item>
+                  </ItemGroup>
+                </CardContent>
+              ) : null}
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Safety and matching checks</CardTitle>
+                <CardDescription>
+                  Errors are blocking; warnings identify deployment-specific risk to review.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <ItemGroup className="grid gap-3 md:grid-cols-2">
+                  {analysis.findings.map((finding) => (
+                    <FindingItem key={finding.code} finding={finding} />
+                  ))}
+                </ItemGroup>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Registration-by-registration result</CardTitle>
+                <CardDescription>
+                  Web redirects require exact comparison; native loopback IP redirects may use a
+                  dynamic port.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                {analysis.registrations.length ? (
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Registered URI</TableHead>
+                        <TableHead>Result</TableHead>
+                        <TableHead>Explanation</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {analysis.registrations.map((registration) => (
+                        <TableRow key={registration.uri}>
+                          <TableCell className="max-w-72 whitespace-normal font-mono text-xs break-all">
+                            {registration.uri}
+                          </TableCell>
+                          <TableCell>
+                            <Badge
+                              variant={
+                                registration.matchType === 'exact' ||
+                                registration.matchType === 'loopback-port'
+                                  ? 'default'
+                                  : registration.matchType === 'invalid'
+                                    ? 'destructive'
+                                    : 'outline'
+                              }
+                            >
+                              {MATCH_LABEL[registration.matchType]}
+                            </Badge>
+                          </TableCell>
+                          <TableCell className="whitespace-normal">{registration.detail}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                ) : (
+                  <Alert>
+                    <Info />
+                    <AlertTitle>Add the registration allowlist</AlertTitle>
+                    <AlertDescription>
+                      URI structure checks are available, but matching cannot be evaluated yet.
+                    </AlertDescription>
+                  </Alert>
+                )}
+              </CardContent>
+            </Card>
+          </>
+        ) : (
+          <Empty>
+            <EmptyMedia variant="icon">
+              <Route />
+            </EmptyMedia>
+            <EmptyTitle>Enter a redirect URI</EmptyTitle>
+            <EmptyDescription>
+              The debugger checks exact registration matching, fragments, transport, custom schemes,
+              query retention, loopback exceptions, and wildcard risk.
+            </EmptyDescription>
+          </Empty>
+        )}
+      </div>
+    </PageContainer>
+  )
+}

--- a/src/features/redirect-uri/utils/redirect-uri.ts
+++ b/src/features/redirect-uri/utils/redirect-uri.ts
@@ -1,0 +1,327 @@
+export type RedirectFindingLevel = 'pass' | 'error' | 'warning' | 'info'
+export type RedirectMatchType = 'exact' | 'loopback-port' | 'normalized-only' | 'none' | 'invalid'
+
+export interface RedirectFinding {
+  level: RedirectFindingLevel
+  code: string
+  title: string
+  message: string
+}
+
+export interface RegisteredRedirectEvaluation {
+  uri: string
+  matchType: RedirectMatchType
+  detail: string
+}
+
+export interface RedirectUriAnalysis {
+  requestedUri: string
+  parsed?: {
+    scheme: string
+    host: string
+    port: string
+    path: string
+    query: string
+    fragment: string
+    isLoopback: boolean
+  }
+  matchType: RedirectMatchType
+  matchedRegistration?: string
+  findings: RedirectFinding[]
+  registrations: RegisteredRedirectEvaluation[]
+  safeToSend: boolean
+}
+
+const DANGEROUS_REDIRECT_SCHEMES = new Set(['javascript:', 'data:', 'file:', 'blob:'])
+const REVERSE_DOMAIN_PRIVATE_USE_SCHEME =
+  /^[a-z](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+$/
+
+function parseAbsoluteUri(value: string): URL | null {
+  try {
+    const parsed = new URL(value)
+    return parsed.protocol && value.includes(':') ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  const normalized = hostname.toLowerCase()
+  return normalized === '127.0.0.1' || normalized === '[::1]' || normalized === '::1'
+}
+
+function isLocalhost(hostname: string): boolean {
+  return hostname.toLowerCase() === 'localhost'
+}
+
+function isHttpLoopback(url: URL): boolean {
+  return url.protocol === 'http:' && isLoopbackHost(url.hostname)
+}
+
+function isReverseDomainPrivateUseScheme(protocol: string): boolean {
+  return REVERSE_DOMAIN_PRIVATE_USE_SCHEME.test(protocol.slice(0, -1))
+}
+
+function matchesLoopbackPortException(requested: URL, registered: URL): boolean {
+  if (!isHttpLoopback(requested) || !isHttpLoopback(registered)) return false
+
+  return (
+    requested.protocol === registered.protocol &&
+    requested.hostname.toLowerCase() === registered.hostname.toLowerCase() &&
+    requested.pathname === registered.pathname &&
+    requested.search === registered.search &&
+    requested.hash === registered.hash
+  )
+}
+
+function normalizedUri(url: URL): string {
+  return `${url.protocol.toLowerCase()}//${url.host.toLowerCase()}${url.pathname}${url.search}${url.hash}`
+}
+
+function evaluateRegistration(
+  requestedRaw: string,
+  requested: URL,
+  registeredRaw: string
+): RegisteredRedirectEvaluation {
+  const registered = parseAbsoluteUri(registeredRaw)
+  if (!registered) {
+    return {
+      uri: registeredRaw,
+      matchType: 'invalid',
+      detail: 'The registered value is not an absolute URI.',
+    }
+  }
+  if (requestedRaw === registeredRaw) {
+    return { uri: registeredRaw, matchType: 'exact', detail: 'Exact string match.' }
+  }
+  if (matchesLoopbackPortException(requested, registered)) {
+    return {
+      uri: registeredRaw,
+      matchType: 'loopback-port',
+      detail: 'Matches a native-app loopback registration except for its dynamic port.',
+    }
+  }
+  if (normalizedUri(requested) === normalizedUri(registered)) {
+    return {
+      uri: registeredRaw,
+      matchType: 'normalized-only',
+      detail: 'Equivalent after URL normalization, but not an exact registered string.',
+    }
+  }
+
+  const sameOrigin = requested.origin !== 'null' && requested.origin === registered.origin
+  return {
+    uri: registeredRaw,
+    matchType: 'none',
+    detail: sameOrigin
+      ? 'Same origin, but path, query, fragment, or exact text differs.'
+      : 'No match.',
+  }
+}
+
+export function parseRegisteredRedirects(input: string): string[] {
+  return [
+    ...new Set(
+      input
+        .split(/\r?\n/)
+        .map((value) => value.trim())
+        .filter(Boolean)
+    ),
+  ]
+}
+
+export function analyzeRedirectUri(
+  requestedInput: string,
+  registeredInput: string | string[]
+): RedirectUriAnalysis {
+  const requestedRaw = requestedInput.trim()
+  const registered = Array.isArray(registeredInput)
+    ? registeredInput.map((value) => value.trim()).filter(Boolean)
+    : parseRegisteredRedirects(registeredInput)
+  const requested = parseAbsoluteUri(requestedRaw)
+  const findings: RedirectFinding[] = []
+
+  if (!requested) {
+    return {
+      requestedUri: requestedRaw,
+      matchType: 'invalid',
+      findings: [
+        {
+          level: 'error',
+          code: 'invalid-uri',
+          title: 'Invalid redirect URI',
+          message: 'The requested redirect must be an absolute URI with a scheme.',
+        },
+      ],
+      registrations: registered.map((uri) => ({
+        uri,
+        matchType: parseAbsoluteUri(uri) ? 'none' : 'invalid',
+        detail: parseAbsoluteUri(uri)
+          ? 'Requested URI is invalid.'
+          : 'The registered value is invalid.',
+      })),
+      safeToSend: false,
+    }
+  }
+
+  const registrations = registered.map((uri) => evaluateRegistration(requestedRaw, requested, uri))
+  const preferredMatch =
+    registrations.find((item) => item.matchType === 'exact') ??
+    registrations.find((item) => item.matchType === 'loopback-port') ??
+    registrations.find((item) => item.matchType === 'normalized-only')
+  const matchType = preferredMatch?.matchType ?? 'none'
+
+  if (requested.hash) {
+    findings.push({
+      level: 'error',
+      code: 'fragment-prohibited',
+      title: 'Fragments are not allowed',
+      message: 'OAuth redirect URIs must not contain a #fragment component.',
+    })
+  }
+
+  if (requested.username || requested.password) {
+    findings.push({
+      level: 'error',
+      code: 'userinfo-prohibited',
+      title: 'Embedded credentials',
+      message: 'Remove the username or password component from this redirect URI.',
+    })
+  }
+
+  if (DANGEROUS_REDIRECT_SCHEMES.has(requested.protocol)) {
+    findings.push({
+      level: 'error',
+      code: 'dangerous-scheme',
+      title: 'Dangerous redirect scheme',
+      message: `${requested.protocol.slice(0, -1)} URIs must never be used as OAuth redirect endpoints.`,
+    })
+  }
+
+  if (requested.protocol === 'http:') {
+    if (isHttpLoopback(requested)) {
+      findings.push({
+        level: 'pass',
+        code: 'loopback-http',
+        title: 'Native loopback redirect',
+        message: 'HTTP is acceptable for a loopback IP redirect that never leaves the device.',
+      })
+    } else if (isLocalhost(requested.hostname)) {
+      findings.push({
+        level: 'warning',
+        code: 'localhost-not-recommended',
+        title: 'Prefer a loopback IP literal',
+        message:
+          'For native apps, 127.0.0.1 or [::1] is safer and more predictable than localhost.',
+      })
+    } else {
+      findings.push({
+        level: 'error',
+        code: 'insecure-http',
+        title: 'Insecure network redirect',
+        message: 'Use HTTPS unless this is an explicit native-app loopback redirect.',
+      })
+    }
+  } else if (requested.protocol === 'https:') {
+    findings.push({
+      level: 'pass',
+      code: 'https',
+      title: 'HTTPS transport',
+      message: 'The redirect uses an authenticated, encrypted web origin.',
+    })
+  } else if (isReverseDomainPrivateUseScheme(requested.protocol)) {
+    const scheme = requested.protocol.slice(0, -1)
+    findings.push({
+      level: 'info',
+      code: 'custom-scheme',
+      title: 'Custom URI scheme',
+      message: `The reverse-domain ${scheme} scheme looks suitable for a native app; confirm the app exclusively claims it.`,
+    })
+  } else if (!DANGEROUS_REDIRECT_SCHEMES.has(requested.protocol)) {
+    findings.push({
+      level: 'error',
+      code: 'unsupported-scheme',
+      title: 'Unsupported redirect scheme',
+      message:
+        'Use HTTPS, a native loopback HTTP URI, or a reverse-domain private-use scheme controlled by the app.',
+    })
+  }
+
+  if (!registered.length) {
+    findings.push({
+      level: 'warning',
+      code: 'no-registrations',
+      title: 'No registered allowlist supplied',
+      message: 'Add the client registration values to verify the redirect match.',
+    })
+  } else if (matchType === 'exact') {
+    findings.push({
+      level: 'pass',
+      code: 'exact-match',
+      title: 'Exact registration match',
+      message: 'The requested URI exactly matches a registered value.',
+    })
+  } else if (matchType === 'loopback-port') {
+    findings.push({
+      level: 'pass',
+      code: 'loopback-port-match',
+      title: 'Loopback port exception',
+      message: 'Only the dynamic port differs from the registered loopback redirect.',
+    })
+  } else if (matchType === 'normalized-only') {
+    findings.push({
+      level: 'error',
+      code: 'not-exact',
+      title: 'Equivalent is not exact',
+      message: 'Do not normalize or partially match web redirect URIs at authorization time.',
+    })
+  } else {
+    findings.push({
+      level: 'error',
+      code: 'not-registered',
+      title: 'Redirect is not registered',
+      message: 'The requested URI does not match any supplied client registration value.',
+    })
+  }
+
+  const wildcardRegistrations = registered.filter((uri) => uri.includes('*'))
+  if (wildcardRegistrations.length) {
+    findings.push({
+      level: 'error',
+      code: 'wildcard-registration',
+      title: 'Wildcard registration detected',
+      message:
+        'Wildcard redirect matching can send authorization responses to attacker-controlled locations.',
+    })
+  }
+
+  if (requested.search) {
+    findings.push({
+      level: 'info',
+      code: 'query-retention',
+      title: 'Registered query must be retained',
+      message:
+        'Authorization response parameters are appended while this existing query remains intact.',
+    })
+  }
+
+  return {
+    requestedUri: requestedRaw,
+    parsed: {
+      scheme: requested.protocol.slice(0, -1),
+      host: requested.hostname,
+      port: requested.port,
+      path: requested.pathname,
+      query: requested.search,
+      fragment: requested.hash,
+      isLoopback: isLoopbackHost(requested.hostname),
+    },
+    matchType,
+    matchedRegistration: preferredMatch?.uri,
+    findings,
+    registrations,
+    safeToSend:
+      !findings.some((finding) => finding.level === 'error') &&
+      (matchType === 'exact' || matchType === 'loopback-port'),
+  }
+}

--- a/src/features/scim/pages/patch-builder/index.tsx
+++ b/src/features/scim/pages/patch-builder/index.tsx
@@ -1,0 +1,378 @@
+import { useMemo, useState } from 'react'
+import { Braces, ListPlus, Plus, ShieldCheck, Sparkles, Trash2, X } from 'lucide-react'
+import { PageContainer, PageHeader } from '@/components/page'
+import { JsonDisplay } from '@/components/common'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from '@/components/ui/empty'
+import { Field, FieldDescription, FieldError, FieldGroup, FieldLabel } from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
+import { Item, ItemContent, ItemDescription, ItemGroup, ItemTitle } from '@/components/ui/item'
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  SCIM_PATCH_OP_SCHEMA,
+  buildScimPatch,
+  validateScimPatch,
+  type ScimDiagnosticSeverity,
+  type ScimPatchOperationInput,
+  type ScimPatchOperationName,
+} from '@/features/scim/utils'
+
+interface DraftOperation {
+  id: string
+  op: ScimPatchOperationName
+  path: string
+  value: string
+}
+
+const RAW_PATCH_EXAMPLE = JSON.stringify(
+  {
+    schemas: [SCIM_PATCH_OP_SCHEMA],
+    Operations: [
+      { op: 'replace', path: 'active', value: false },
+      { op: 'add', path: 'roles', value: [{ value: 'billing-viewer' }] },
+      { op: 'remove', path: 'emails[type eq "home"]' },
+    ],
+  },
+  null,
+  2
+)
+
+const SEVERITY_VARIANT: Record<ScimDiagnosticSeverity, 'destructive' | 'secondary' | 'outline'> = {
+  error: 'destructive',
+  warning: 'secondary',
+  info: 'outline',
+}
+
+function createDraft(op: ScimPatchOperationName = 'replace'): DraftOperation {
+  return {
+    id: crypto.randomUUID(),
+    op,
+    path: op === 'replace' ? 'active' : '',
+    value: op === 'remove' ? '' : 'true',
+  }
+}
+
+function toOperationInputs(drafts: DraftOperation[]): ScimPatchOperationInput[] {
+  return drafts.map((draft, index) => {
+    const path = draft.path.trim()
+    if (draft.op === 'remove') {
+      if (!path) throw new Error(`Operation ${index + 1}: remove requires a path.`)
+      return { op: 'remove', path }
+    }
+
+    if (!draft.value.trim()) {
+      throw new Error(`Operation ${index + 1}: ${draft.op} requires a JSON value.`)
+    }
+
+    let value: unknown
+    try {
+      value = JSON.parse(draft.value)
+    } catch {
+      throw new Error(
+        `Operation ${index + 1}: value must be valid JSON. Wrap string values in quotes.`
+      )
+    }
+
+    return {
+      op: draft.op,
+      ...(path ? { path } : {}),
+      value,
+    }
+  })
+}
+
+export default function ScimPatchBuilderPage() {
+  const [drafts, setDrafts] = useState<DraftOperation[]>(() => [createDraft()])
+  const [rawInput, setRawInput] = useState('')
+
+  const buildState = useMemo(() => {
+    try {
+      const result = buildScimPatch(toOperationInputs(drafts))
+      return { result, error: null }
+    } catch (error) {
+      return {
+        result: null,
+        error: error instanceof Error ? error.message : 'Unable to build this PATCH document.',
+      }
+    }
+  }, [drafts])
+
+  const validation = useMemo(
+    () => (rawInput.trim() ? validateScimPatch(rawInput) : null),
+    [rawInput]
+  )
+
+  const updateDraft = (id: string, updates: Partial<DraftOperation>) => {
+    setDrafts((current) =>
+      current.map((draft) =>
+        draft.id === id
+          ? {
+              ...draft,
+              ...updates,
+              ...(updates.op === 'remove' ? { value: '' } : {}),
+            }
+          : draft
+      )
+    )
+  }
+
+  const removeDraft = (id: string) => {
+    setDrafts((current) => current.filter((draft) => draft.id !== id))
+  }
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="SCIM PATCH Builder"
+        description="Compose canonical RFC 7644 add, remove, and replace operations, or validate an existing PatchOp document."
+        icon={ListPlus}
+      />
+
+      <div className="flex flex-col gap-6" data-testid="scim-patch-builder-root">
+        <Alert>
+          <ShieldCheck />
+          <AlertTitle>Build safely before sending</AlertTitle>
+          <AlertDescription>
+            This tool creates and validates JSON only. It does not call a SCIM endpoint or retain
+            provisioning data.
+          </AlertDescription>
+        </Alert>
+
+        <Tabs defaultValue="builder">
+          <TabsList className="grid w-full grid-cols-2 sm:w-fit">
+            <TabsTrigger value="builder">Visual builder</TabsTrigger>
+            <TabsTrigger value="validator">Raw validator</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="builder" className="flex flex-col gap-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Operations</CardTitle>
+                <CardDescription>
+                  Paths use SCIM attribute-path syntax. Add and replace values must be valid JSON.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="flex flex-col gap-4">
+                {drafts.map((draft, index) => (
+                  <Card key={draft.id} className="gap-4 py-4">
+                    <CardHeader>
+                      <CardTitle>Operation {index + 1}</CardTitle>
+                      <CardDescription>{draft.op.toUpperCase()}</CardDescription>
+                      <CardAction>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          aria-label={`Remove operation ${index + 1}`}
+                          onClick={() => removeDraft(draft.id)}
+                          disabled={drafts.length === 1}
+                        >
+                          <X aria-hidden="true" />
+                        </Button>
+                      </CardAction>
+                    </CardHeader>
+                    <CardContent>
+                      <FieldGroup>
+                        <Field>
+                          <FieldLabel htmlFor={`${draft.id}-op`}>Operation</FieldLabel>
+                          <Select
+                            value={draft.op}
+                            onValueChange={(value) =>
+                              updateDraft(draft.id, { op: value as ScimPatchOperationName })
+                            }
+                          >
+                            <SelectTrigger id={`${draft.id}-op`} className="w-full">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectGroup>
+                                <SelectItem value="add">add</SelectItem>
+                                <SelectItem value="remove">remove</SelectItem>
+                                <SelectItem value="replace">replace</SelectItem>
+                              </SelectGroup>
+                            </SelectContent>
+                          </Select>
+                        </Field>
+
+                        <Field>
+                          <FieldLabel htmlFor={`${draft.id}-path`}>
+                            Path {draft.op === 'remove' ? '(required)' : '(optional)'}
+                          </FieldLabel>
+                          <Input
+                            id={`${draft.id}-path`}
+                            value={draft.path}
+                            onChange={(event) =>
+                              updateDraft(draft.id, { path: event.target.value })
+                            }
+                            placeholder={'emails[type eq "work"].value'}
+                            autoComplete="off"
+                            spellCheck={false}
+                          />
+                        </Field>
+
+                        {draft.op === 'remove' ? null : (
+                          <Field>
+                            <FieldLabel htmlFor={`${draft.id}-value`}>JSON value</FieldLabel>
+                            <Textarea
+                              id={`${draft.id}-value`}
+                              value={draft.value}
+                              onChange={(event) =>
+                                updateDraft(draft.id, { value: event.target.value })
+                              }
+                              placeholder={'[{ "value": "billing-viewer" }]'}
+                              className="min-h-24 font-mono text-xs"
+                              spellCheck={false}
+                            />
+                            <FieldDescription>
+                              Use <code>&quot;text&quot;</code> for a string, or enter an object,
+                              array, number, boolean, or null.
+                            </FieldDescription>
+                          </Field>
+                        )}
+                      </FieldGroup>
+                    </CardContent>
+                  </Card>
+                ))}
+              </CardContent>
+              <CardFooter>
+                <Button
+                  variant="outline"
+                  onClick={() => setDrafts((current) => [...current, createDraft('add')])}
+                >
+                  <Plus data-icon="inline-start" />
+                  Add operation
+                </Button>
+              </CardFooter>
+            </Card>
+
+            {buildState.result ? (
+              <Card>
+                <CardHeader>
+                  <CardTitle>Canonical PatchOp document</CardTitle>
+                  <CardDescription>
+                    Ready to use as an <code>application/scim+json</code> PATCH body.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <JsonDisplay data={buildState.result.document} maxHeight="32rem" />
+                </CardContent>
+              </Card>
+            ) : (
+              <Alert variant="destructive">
+                <Braces />
+                <AlertTitle>Cannot build the document yet</AlertTitle>
+                <AlertDescription>{buildState.error}</AlertDescription>
+              </Alert>
+            )}
+          </TabsContent>
+
+          <TabsContent value="validator" className="flex flex-col gap-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Existing PatchOp JSON</CardTitle>
+                <CardDescription>
+                  Validate schema declarations, operation semantics, required fields, and paths.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Field data-invalid={Boolean(validation && !validation.valid)}>
+                  <FieldLabel htmlFor="scim-patch-raw-input">PATCH document</FieldLabel>
+                  <Textarea
+                    id="scim-patch-raw-input"
+                    value={rawInput}
+                    onChange={(event) => setRawInput(event.target.value)}
+                    placeholder={RAW_PATCH_EXAMPLE}
+                    className="min-h-80 font-mono text-xs"
+                    spellCheck={false}
+                    aria-invalid={Boolean(validation && !validation.valid)}
+                    data-testid="scim-patch-raw-input"
+                  />
+                  {validation && !validation.valid ? (
+                    <FieldError>Fix the blocking diagnostics below.</FieldError>
+                  ) : null}
+                </Field>
+              </CardContent>
+              <CardFooter className="flex-wrap gap-2">
+                <Button
+                  onClick={() => setRawInput(RAW_PATCH_EXAMPLE)}
+                  data-testid="scim-patch-example"
+                >
+                  <Sparkles data-icon="inline-start" />
+                  Load example
+                </Button>
+                <Button variant="ghost" onClick={() => setRawInput('')} disabled={!rawInput}>
+                  <Trash2 data-icon="inline-start" />
+                  Clear
+                </Button>
+              </CardFooter>
+            </Card>
+
+            {validation ? (
+              <>
+                <Item>
+                  <ItemContent>
+                    <ItemTitle>{validation.valid ? 'Valid PatchOp' : 'Invalid PatchOp'}</ItemTitle>
+                    <ItemDescription>
+                      Parsed {validation.operations.length} canonical operation
+                      {validation.operations.length === 1 ? '' : 's'}.
+                    </ItemDescription>
+                  </ItemContent>
+                  <Badge variant={validation.valid ? 'default' : 'destructive'}>
+                    {validation.valid ? 'Valid' : 'Invalid'}
+                  </Badge>
+                </Item>
+
+                <ItemGroup className="grid gap-3 md:grid-cols-2">
+                  {validation.diagnostics.map((diagnostic) => (
+                    <Item key={`${diagnostic.code}-${diagnostic.path}-${diagnostic.message}`}>
+                      <ItemContent>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <ItemTitle>{diagnostic.message}</ItemTitle>
+                          <Badge variant={SEVERITY_VARIANT[diagnostic.severity]}>
+                            {diagnostic.severity}
+                          </Badge>
+                        </div>
+                        <ItemDescription className="font-mono text-xs break-all">
+                          {diagnostic.path} · {diagnostic.code}
+                        </ItemDescription>
+                      </ItemContent>
+                    </Item>
+                  ))}
+                </ItemGroup>
+              </>
+            ) : (
+              <Empty>
+                <EmptyMedia variant="icon">
+                  <Braces />
+                </EmptyMedia>
+                <EmptyTitle>Paste a PatchOp document</EmptyTitle>
+                <EmptyDescription>
+                  Use the example to see a combined replace, add, and filtered remove request.
+                </EmptyDescription>
+              </Empty>
+            )}
+          </TabsContent>
+        </Tabs>
+      </div>
+    </PageContainer>
+  )
+}

--- a/src/features/scim/pages/resource-validator/index.tsx
+++ b/src/features/scim/pages/resource-validator/index.tsx
@@ -1,0 +1,247 @@
+import { useMemo, useState } from 'react'
+import { Braces, ShieldCheck, Sparkles, Trash2, UserCheck, UsersRound } from 'lucide-react'
+import { PageContainer, PageHeader } from '@/components/page'
+import { JsonDisplay } from '@/components/common'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from '@/components/ui/empty'
+import { Field, FieldDescription, FieldLabel } from '@/components/ui/field'
+import { Item, ItemContent, ItemDescription, ItemGroup, ItemTitle } from '@/components/ui/item'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  SCIM_ENTERPRISE_USER_SCHEMA,
+  SCIM_GROUP_SCHEMA,
+  SCIM_USER_SCHEMA,
+  validateScimResource,
+  type ScimDiagnostic,
+  type ScimDiagnosticSeverity,
+} from '@/features/scim/utils'
+
+const DIAGNOSTIC_VARIANT: Record<ScimDiagnosticSeverity, 'destructive' | 'secondary' | 'outline'> =
+  {
+    error: 'destructive',
+    warning: 'secondary',
+    info: 'outline',
+  }
+
+const USER_EXAMPLE = JSON.stringify(
+  {
+    schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+    externalId: 'employee-701984',
+    userName: 'bjensen@example.com',
+    active: true,
+    name: {
+      givenName: 'Barbara',
+      familyName: 'Jensen',
+      formatted: 'Barbara Jensen',
+    },
+    displayName: 'Barbara Jensen',
+    emails: [{ value: 'bjensen@example.com', type: 'work', primary: true }],
+    [SCIM_ENTERPRISE_USER_SCHEMA]: {
+      employeeNumber: '701984',
+      department: 'Tour Operations',
+      manager: { value: 'manager-26118915' },
+    },
+  },
+  null,
+  2
+)
+
+const GROUP_EXAMPLE = JSON.stringify(
+  {
+    schemas: [SCIM_GROUP_SCHEMA],
+    displayName: 'Tour Guides',
+    members: [
+      { value: 'user-2819c223', display: 'Barbara Jensen' },
+      { value: 'user-9025315', display: 'James Smith' },
+    ],
+  },
+  null,
+  2
+)
+
+function DiagnosticItem({ diagnostic }: { diagnostic: ScimDiagnostic }) {
+  return (
+    <Item>
+      <ItemContent>
+        <div className="flex flex-wrap items-center gap-2">
+          <ItemTitle>{diagnostic.message}</ItemTitle>
+          <Badge variant={DIAGNOSTIC_VARIANT[diagnostic.severity]}>{diagnostic.severity}</Badge>
+        </div>
+        <ItemDescription className="font-mono text-xs break-all">
+          {diagnostic.path} · {diagnostic.code}
+        </ItemDescription>
+      </ItemContent>
+    </Item>
+  )
+}
+
+export default function ScimResourceValidatorPage() {
+  const [input, setInput] = useState('')
+  const result = useMemo(() => (input.trim() ? validateScimResource(input) : null), [input])
+  const counts = useMemo(
+    () => ({
+      error: result?.diagnostics.filter((item) => item.severity === 'error').length ?? 0,
+      warning: result?.diagnostics.filter((item) => item.severity === 'warning').length ?? 0,
+      info: result?.diagnostics.filter((item) => item.severity === 'info').length ?? 0,
+    }),
+    [result]
+  )
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="SCIM Resource Validator"
+        description="Validate SCIM 2.0 User, Group, and Enterprise User JSON with precise schema-aware diagnostics."
+        icon={UserCheck}
+      />
+
+      <div className="flex flex-col gap-6" data-testid="scim-resource-validator-root">
+        <Alert>
+          <ShieldCheck />
+          <AlertTitle>Provisioning data stays local</AlertTitle>
+          <AlertDescription>
+            SCIM resources often contain personal data. This validator performs no network calls and
+            does not save pasted resources to browser storage.
+          </AlertDescription>
+        </Alert>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Resource JSON</CardTitle>
+            <CardDescription>
+              Paste a SCIM User or Group representation. Custom extensions are checked for schema
+              declaration consistency.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Field data-invalid={Boolean(result && !result.valid)}>
+              <FieldLabel htmlFor="scim-resource-input">SCIM resource</FieldLabel>
+              <Textarea
+                id="scim-resource-input"
+                value={input}
+                onChange={(event) => setInput(event.target.value)}
+                placeholder={`{\n  "schemas": ["${SCIM_USER_SCHEMA}"],\n  "userName": "bjensen@example.com"\n}`}
+                className="min-h-80 font-mono text-xs"
+                autoComplete="off"
+                spellCheck={false}
+                aria-invalid={Boolean(result && !result.valid)}
+                data-testid="scim-resource-input"
+              />
+              <FieldDescription>
+                Structural validation covers core required fields, common types, multi-valued
+                attributes, primary values, metadata, and extensions.
+              </FieldDescription>
+            </Field>
+          </CardContent>
+          <CardFooter className="flex-wrap gap-2">
+            <Button onClick={() => setInput(USER_EXAMPLE)} data-testid="scim-resource-user-example">
+              <Sparkles data-icon="inline-start" />
+              Load User example
+            </Button>
+            <Button variant="outline" onClick={() => setInput(GROUP_EXAMPLE)}>
+              <UsersRound data-icon="inline-start" />
+              Load Group example
+            </Button>
+            <Button variant="ghost" onClick={() => setInput('')} disabled={!input}>
+              <Trash2 data-icon="inline-start" />
+              Clear
+            </Button>
+          </CardFooter>
+        </Card>
+
+        {result ? (
+          <>
+            <ItemGroup className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+              <Item>
+                <ItemContent>
+                  <ItemTitle>Result</ItemTitle>
+                  <ItemDescription>
+                    {result.valid ? 'No structural errors' : 'Needs attention'}
+                  </ItemDescription>
+                </ItemContent>
+                <Badge variant={result.valid ? 'default' : 'destructive'}>
+                  {result.valid ? 'Valid' : 'Invalid'}
+                </Badge>
+              </Item>
+              <Item>
+                <ItemContent>
+                  <ItemTitle>Resource type</ItemTitle>
+                  <ItemDescription>Detected from the core schema URN</ItemDescription>
+                </ItemContent>
+                <Badge variant="outline">{result.resourceType}</Badge>
+              </Item>
+              <Item>
+                <ItemContent>
+                  <ItemTitle>Errors</ItemTitle>
+                  <ItemDescription>Blocking conformance issues</ItemDescription>
+                </ItemContent>
+                <Badge variant={counts.error ? 'destructive' : 'outline'}>{counts.error}</Badge>
+              </Item>
+              <Item>
+                <ItemContent>
+                  <ItemTitle>Warnings</ItemTitle>
+                  <ItemDescription>Interoperability details to review</ItemDescription>
+                </ItemContent>
+                <Badge variant="secondary">{counts.warning}</Badge>
+              </Item>
+            </ItemGroup>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Diagnostics</CardTitle>
+                <CardDescription>
+                  Paths point to the exact JSON attribute involved in each check.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <ItemGroup className="grid gap-3 md:grid-cols-2">
+                  {result.diagnostics.map((diagnostic) => (
+                    <DiagnosticItem
+                      key={`${diagnostic.code}-${diagnostic.path}-${diagnostic.message}`}
+                      diagnostic={diagnostic}
+                    />
+                  ))}
+                </ItemGroup>
+              </CardContent>
+            </Card>
+
+            {result.parsed ? (
+              <Card>
+                <CardHeader>
+                  <CardTitle>Normalized JSON</CardTitle>
+                  <CardDescription>
+                    Formatting only; attribute names, values, and ordering semantics are unchanged.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <JsonDisplay data={result.parsed} maxHeight="32rem" />
+                </CardContent>
+              </Card>
+            ) : null}
+          </>
+        ) : (
+          <Empty>
+            <EmptyMedia variant="icon">
+              <Braces />
+            </EmptyMedia>
+            <EmptyTitle>Paste a SCIM resource</EmptyTitle>
+            <EmptyDescription>
+              Start with a local example or paste a sanitized provisioning payload to receive
+              field-level diagnostics.
+            </EmptyDescription>
+          </Empty>
+        )}
+      </div>
+    </PageContainer>
+  )
+}

--- a/src/features/scim/utils/constants.ts
+++ b/src/features/scim/utils/constants.ts
@@ -1,0 +1,12 @@
+/** SCIM 2.0 core User resource schema (RFC 7643 section 4.1). */
+export const SCIM_USER_SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:User' as const
+
+/** SCIM 2.0 core Group resource schema (RFC 7643 section 4.2). */
+export const SCIM_GROUP_SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:Group' as const
+
+/** SCIM 2.0 Enterprise User extension schema (RFC 7643 section 4.3). */
+export const SCIM_ENTERPRISE_USER_SCHEMA =
+  'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User' as const
+
+/** SCIM 2.0 PATCH request schema (RFC 7644 section 3.5.2). */
+export const SCIM_PATCH_OP_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:PatchOp' as const

--- a/src/features/scim/utils/index.ts
+++ b/src/features/scim/utils/index.ts
@@ -1,0 +1,21 @@
+export {
+  SCIM_USER_SCHEMA,
+  SCIM_GROUP_SCHEMA,
+  SCIM_ENTERPRISE_USER_SCHEMA,
+  SCIM_PATCH_OP_SCHEMA,
+} from './constants'
+export { isValidScimPath } from './path'
+export { validateScimResource } from './resource-validation'
+export { buildScimPatch, validateScimPatch } from './patch'
+export type {
+  ScimDiagnostic,
+  ScimDiagnosticSeverity,
+  ScimPatchBuildResult,
+  ScimPatchDocument,
+  ScimPatchOperation,
+  ScimPatchOperationInput,
+  ScimPatchOperationName,
+  ScimPatchValidationResult,
+  ScimResourceType,
+  ScimResourceValidationResult,
+} from './types'

--- a/src/features/scim/utils/patch.ts
+++ b/src/features/scim/utils/patch.ts
@@ -1,0 +1,332 @@
+import { SCIM_PATCH_OP_SCHEMA } from './constants'
+import { isValidScimPath } from './path'
+import type {
+  ScimDiagnostic,
+  ScimDiagnosticSeverity,
+  ScimPatchBuildResult,
+  ScimPatchDocument,
+  ScimPatchOperation,
+  ScimPatchOperationInput,
+  ScimPatchOperationName,
+  ScimPatchValidationResult,
+} from './types'
+
+type ScimObject = Record<string, unknown>
+
+const ALLOWED_OPERATIONS = new Set<ScimPatchOperationName>(['add', 'remove', 'replace'])
+
+function isObject(value: unknown): value is ScimObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function hasOwn(object: ScimObject, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(object, key)
+}
+
+function diagnostic(
+  diagnostics: ScimDiagnostic[],
+  severity: ScimDiagnosticSeverity,
+  path: string,
+  code: string,
+  message: string
+): void {
+  diagnostics.push({ severity, path, code, message })
+}
+
+function parsePatchSchemas(patch: ScimObject, diagnostics: ScimDiagnostic[]): void {
+  if (!hasOwn(patch, 'schemas')) {
+    diagnostic(
+      diagnostics,
+      'error',
+      '$.schemas',
+      'schemas_missing',
+      'PATCH documents require a schemas array.'
+    )
+    return
+  }
+
+  if (!Array.isArray(patch.schemas)) {
+    diagnostic(
+      diagnostics,
+      'error',
+      '$.schemas',
+      'schemas_type',
+      'schemas must be an array of strings.'
+    )
+    return
+  }
+
+  const patchSchemaCount = patch.schemas.filter((schema) => schema === SCIM_PATCH_OP_SCHEMA).length
+  if (patchSchemaCount === 0) {
+    diagnostic(
+      diagnostics,
+      'error',
+      '$.schemas',
+      'patch_schema_missing',
+      `schemas must include ${SCIM_PATCH_OP_SCHEMA}.`
+    )
+  } else if (patchSchemaCount > 1) {
+    diagnostic(
+      diagnostics,
+      'warning',
+      '$.schemas',
+      'duplicate_schema',
+      'The PatchOp schema is declared more than once.'
+    )
+  }
+
+  patch.schemas.forEach((schema, index) => {
+    if (typeof schema !== 'string' || !schema.trim()) {
+      diagnostic(
+        diagnostics,
+        'error',
+        `$.schemas[${index}]`,
+        'schema_uri_type',
+        'Each schemas entry must be a non-empty string.'
+      )
+    } else if (schema !== SCIM_PATCH_OP_SCHEMA) {
+      diagnostic(
+        diagnostics,
+        'warning',
+        `$.schemas[${index}]`,
+        'unexpected_patch_schema',
+        `PATCH documents normally declare only ${SCIM_PATCH_OP_SCHEMA}.`
+      )
+    }
+  })
+}
+
+function normalizeOperation(
+  value: unknown,
+  index: number,
+  diagnostics: ScimDiagnostic[]
+): ScimPatchOperation | null {
+  const operationPath = `$.Operations[${index}]`
+  if (!isObject(value)) {
+    diagnostic(
+      diagnostics,
+      'error',
+      operationPath,
+      'operation_type',
+      'Each PATCH operation must be an object.'
+    )
+    return null
+  }
+
+  if (typeof value.op !== 'string') {
+    diagnostic(
+      diagnostics,
+      'error',
+      `${operationPath}.op`,
+      'operation_name_missing',
+      'op must be add, remove, or replace.'
+    )
+    return null
+  }
+
+  const op = value.op.toLowerCase() as ScimPatchOperationName
+  if (!ALLOWED_OPERATIONS.has(op)) {
+    diagnostic(
+      diagnostics,
+      'error',
+      `${operationPath}.op`,
+      'operation_name_invalid',
+      `Unsupported PATCH operation ${value.op}. Use add, remove, or replace.`
+    )
+    return null
+  }
+
+  if (value.op !== op) {
+    diagnostic(
+      diagnostics,
+      'warning',
+      `${operationPath}.op`,
+      'operation_name_case',
+      `Use lowercase ${op} for a canonical PATCH document.`
+    )
+  }
+
+  let path: string | undefined
+  if (hasOwn(value, 'path')) {
+    if (typeof value.path !== 'string' || !value.path.trim()) {
+      diagnostic(
+        diagnostics,
+        'error',
+        `${operationPath}.path`,
+        'operation_path_type',
+        'path must be a non-empty string when provided.'
+      )
+    } else {
+      path = value.path.trim()
+      if (!isValidScimPath(path)) {
+        diagnostic(
+          diagnostics,
+          'error',
+          `${operationPath}.path`,
+          'operation_path_syntax',
+          `Invalid SCIM attribute path: ${path}.`
+        )
+      }
+    }
+  }
+
+  if (op === 'remove' && !path) {
+    diagnostic(
+      diagnostics,
+      'error',
+      `${operationPath}.path`,
+      'remove_path_required',
+      'remove operations require a path.'
+    )
+  }
+
+  const hasValue = hasOwn(value, 'value') && value.value !== undefined
+  if ((op === 'add' || op === 'replace') && !hasValue) {
+    diagnostic(
+      diagnostics,
+      'error',
+      `${operationPath}.value`,
+      'operation_value_required',
+      `${op} operations require a value.`
+    )
+  }
+
+  if (op === 'remove' && hasValue) {
+    diagnostic(
+      diagnostics,
+      'warning',
+      `${operationPath}.value`,
+      'remove_value_ignored',
+      'remove operations do not use value; it will be ignored by the canonical builder.'
+    )
+  }
+
+  return {
+    op,
+    ...(path ? { path } : {}),
+    ...(op !== 'remove' && hasValue ? { value: value.value } : {}),
+  }
+}
+
+/** Validate an RFC 7644 PATCH request represented as JSON text. */
+export function validateScimPatch(input: string): ScimPatchValidationResult {
+  const diagnostics: ScimDiagnostic[] = []
+  if (!input.trim()) {
+    diagnostic(diagnostics, 'error', '$', 'empty_input', 'Enter a SCIM PATCH document as JSON.')
+    return { valid: false, parsed: null, operations: [], diagnostics }
+  }
+
+  let value: unknown
+  try {
+    value = JSON.parse(input)
+  } catch (error) {
+    const detail = error instanceof Error ? ` ${error.message}` : ''
+    diagnostic(diagnostics, 'error', '$', 'invalid_json', `Input is not valid JSON.${detail}`)
+    return { valid: false, parsed: null, operations: [], diagnostics }
+  }
+
+  if (!isObject(value)) {
+    diagnostic(
+      diagnostics,
+      'error',
+      '$',
+      'patch_type',
+      'A SCIM PATCH document must be a JSON object.'
+    )
+    return { valid: false, parsed: null, operations: [], diagnostics }
+  }
+
+  parsePatchSchemas(value, diagnostics)
+
+  const operations: ScimPatchOperation[] = []
+  if (!hasOwn(value, 'Operations')) {
+    diagnostic(
+      diagnostics,
+      'error',
+      '$.Operations',
+      'operations_missing',
+      'Operations is required.'
+    )
+  } else if (!Array.isArray(value.Operations)) {
+    diagnostic(
+      diagnostics,
+      'error',
+      '$.Operations',
+      'operations_type',
+      'Operations must be an array.'
+    )
+  } else if (value.Operations.length === 0) {
+    diagnostic(
+      diagnostics,
+      'error',
+      '$.Operations',
+      'operations_empty',
+      'Operations must contain at least one operation.'
+    )
+  } else {
+    value.Operations.forEach((operation, index) => {
+      const normalized = normalizeOperation(operation, index, diagnostics)
+      if (normalized) operations.push(normalized)
+    })
+    diagnostic(
+      diagnostics,
+      'info',
+      '$.Operations',
+      'operation_count',
+      `Parsed ${value.Operations.length} PATCH operation${value.Operations.length === 1 ? '' : 's'}.`
+    )
+  }
+
+  return {
+    valid: !diagnostics.some((item) => item.severity === 'error'),
+    parsed: value,
+    operations,
+    diagnostics,
+  }
+}
+
+/** Build a validated, canonical RFC 7644 PATCH document and formatted JSON. */
+export function buildScimPatch(
+  operations: readonly ScimPatchOperationInput[]
+): ScimPatchBuildResult {
+  if (operations.length === 0) {
+    throw new RangeError('At least one SCIM PATCH operation is required.')
+  }
+
+  const canonicalOperations: ScimPatchOperation[] = operations.map((operation, index) => {
+    const op = operation.op
+    if (!ALLOWED_OPERATIONS.has(op)) {
+      throw new TypeError(`Operation ${index + 1} has an unsupported op.`)
+    }
+
+    const path = operation.path?.trim()
+    if (operation.path !== undefined && !path) {
+      throw new TypeError(`Operation ${index + 1} has an empty path.`)
+    }
+    if (path && !isValidScimPath(path)) {
+      throw new TypeError(`Operation ${index + 1} has an invalid SCIM path: ${path}.`)
+    }
+    if (op === 'remove' && !path) {
+      throw new TypeError(`Remove operation ${index + 1} requires a path.`)
+    }
+    if ((op === 'add' || op === 'replace') && operation.value === undefined) {
+      throw new TypeError(`${op} operation ${index + 1} requires a value.`)
+    }
+
+    return {
+      op,
+      ...(path ? { path } : {}),
+      ...(op !== 'remove' ? { value: operation.value } : {}),
+    }
+  })
+
+  const document: ScimPatchDocument = {
+    schemas: [SCIM_PATCH_OP_SCHEMA],
+    Operations: canonicalOperations,
+  }
+
+  return {
+    document,
+    json: JSON.stringify(document, null, 2),
+  }
+}

--- a/src/features/scim/utils/path.ts
+++ b/src/features/scim/utils/path.ts
@@ -1,0 +1,67 @@
+const ATTRIBUTE_NAME_PATTERN = /^(?:[A-Za-z][A-Za-z0-9_-]*|\$ref)$/
+const SCHEMA_URI_PATTERN = /^[A-Za-z][A-Za-z0-9+.-]*:[^\s]+$/
+const FILTER_VALUE_PATTERN = '(?:"(?:[^"\\\\]|\\\\.)*"|true|false|null|-?\\d+(?:\\.\\d+)?)'
+const FILTER_PATTERN = new RegExp(
+  `^(?:[A-Za-z][A-Za-z0-9_-]*|\\$ref)(?:\\.(?:[A-Za-z][A-Za-z0-9_-]*|\\$ref))?\\s+(?:pr|(?:eq|ne|co|sw|ew|gt|ge|lt|le)\\s+${FILTER_VALUE_PATTERN})$`,
+  'i'
+)
+
+function isAttributePath(value: string): boolean {
+  let attributePath = value
+  const lastColon = value.lastIndexOf(':')
+
+  if (lastColon !== -1) {
+    const schemaUri = value.slice(0, lastColon)
+    attributePath = value.slice(lastColon + 1)
+
+    if (!SCHEMA_URI_PATTERN.test(schemaUri)) {
+      return false
+    }
+  }
+
+  const segments = attributePath.split('.')
+  return (
+    segments.length >= 1 &&
+    segments.length <= 2 &&
+    segments.every((segment) => ATTRIBUTE_NAME_PATTERN.test(segment))
+  )
+}
+
+/**
+ * Performs a conservative syntax check for the SCIM attribute paths commonly
+ * used by PATCH operations. It supports schema-qualified attributes, one
+ * sub-attribute, and a simple RFC 7644 value filter.
+ */
+export function isValidScimPath(input: string): boolean {
+  const path = input.trim()
+  if (!path) return false
+
+  const openBracket = path.indexOf('[')
+  const closeBracket = path.lastIndexOf(']')
+
+  if (openBracket === -1 && closeBracket === -1) {
+    return isAttributePath(path)
+  }
+
+  if (
+    openBracket <= 0 ||
+    closeBracket <= openBracket + 1 ||
+    path.indexOf('[', openBracket + 1) !== -1 ||
+    path.indexOf(']', closeBracket + 1) !== -1
+  ) {
+    return false
+  }
+
+  const valuePath = path.slice(0, openBracket)
+  const filter = path.slice(openBracket + 1, closeBracket).trim()
+  const suffix = path.slice(closeBracket + 1)
+
+  if (!isAttributePath(valuePath) || !FILTER_PATTERN.test(filter)) {
+    return false
+  }
+
+  if (!suffix) return true
+  if (!suffix.startsWith('.')) return false
+
+  return ATTRIBUTE_NAME_PATTERN.test(suffix.slice(1))
+}

--- a/src/features/scim/utils/resource-validation.ts
+++ b/src/features/scim/utils/resource-validation.ts
@@ -1,0 +1,590 @@
+import { SCIM_ENTERPRISE_USER_SCHEMA, SCIM_GROUP_SCHEMA, SCIM_USER_SCHEMA } from './constants'
+import type {
+  ScimDiagnostic,
+  ScimDiagnosticSeverity,
+  ScimResourceType,
+  ScimResourceValidationResult,
+} from './types'
+
+type ScimObject = Record<string, unknown>
+
+const USER_STRING_ATTRIBUTES = [
+  'displayName',
+  'nickName',
+  'profileUrl',
+  'title',
+  'userType',
+  'preferredLanguage',
+  'locale',
+  'timezone',
+  'password',
+] as const
+
+const COMMON_STRING_ATTRIBUTES = ['id', 'externalId'] as const
+
+const USER_MULTI_VALUE_ATTRIBUTES = [
+  'emails',
+  'phoneNumbers',
+  'ims',
+  'photos',
+  'addresses',
+  'groups',
+  'entitlements',
+  'roles',
+  'x509Certificates',
+] as const
+
+const NAME_SUB_ATTRIBUTES = [
+  'formatted',
+  'familyName',
+  'givenName',
+  'middleName',
+  'honorificPrefix',
+  'honorificSuffix',
+] as const
+
+const ADDRESS_SUB_ATTRIBUTES = [
+  'formatted',
+  'streetAddress',
+  'locality',
+  'region',
+  'postalCode',
+  'country',
+] as const
+
+const ENTERPRISE_STRING_ATTRIBUTES = [
+  'employeeNumber',
+  'costCenter',
+  'organization',
+  'division',
+  'department',
+] as const
+
+function isObject(value: unknown): value is ScimObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function hasOwn(object: ScimObject, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(object, key)
+}
+
+function diagnostic(
+  diagnostics: ScimDiagnostic[],
+  severity: ScimDiagnosticSeverity,
+  path: string,
+  code: string,
+  message: string
+): void {
+  diagnostics.push({ severity, path, code, message })
+}
+
+function propertyPath(parent: string, property: string): string {
+  return /^[A-Za-z_$][A-Za-z0-9_$-]*$/.test(property)
+    ? `${parent}.${property}`
+    : `${parent}[${JSON.stringify(property)}]`
+}
+
+function validateOptionalString(
+  object: ScimObject,
+  attribute: string,
+  parentPath: string,
+  diagnostics: ScimDiagnostic[],
+  options: { nonEmpty?: boolean } = {}
+): void {
+  if (!hasOwn(object, attribute)) return
+
+  const value = object[attribute]
+  const path = propertyPath(parentPath, attribute)
+  if (typeof value !== 'string') {
+    diagnostic(diagnostics, 'error', path, 'attribute_type', `${attribute} must be a string.`)
+    return
+  }
+
+  if (options.nonEmpty && !value.trim()) {
+    diagnostic(
+      diagnostics,
+      'error',
+      path,
+      'required_attribute_empty',
+      `${attribute} must not be empty.`
+    )
+  }
+}
+
+function validateRequiredString(
+  object: ScimObject,
+  attribute: string,
+  diagnostics: ScimDiagnostic[]
+): void {
+  if (!hasOwn(object, attribute)) {
+    diagnostic(
+      diagnostics,
+      'error',
+      propertyPath('$', attribute),
+      'required_attribute_missing',
+      `${attribute} is required.`
+    )
+    return
+  }
+
+  validateOptionalString(object, attribute, '$', diagnostics, { nonEmpty: true })
+}
+
+function validateStringSubAttributes(
+  object: ScimObject,
+  attributes: readonly string[],
+  parentPath: string,
+  diagnostics: ScimDiagnostic[]
+): void {
+  for (const attribute of attributes) {
+    validateOptionalString(object, attribute, parentPath, diagnostics)
+  }
+}
+
+function validateComplexAttribute(
+  resource: ScimObject,
+  attribute: string,
+  stringSubAttributes: readonly string[],
+  diagnostics: ScimDiagnostic[]
+): void {
+  if (!hasOwn(resource, attribute)) return
+
+  const path = propertyPath('$', attribute)
+  const value = resource[attribute]
+  if (!isObject(value)) {
+    diagnostic(
+      diagnostics,
+      'error',
+      path,
+      'complex_attribute_type',
+      `${attribute} must be an object.`
+    )
+    return
+  }
+
+  validateStringSubAttributes(value, stringSubAttributes, path, diagnostics)
+}
+
+function validateMultiValuedAttribute(
+  resource: ScimObject,
+  attribute: string,
+  diagnostics: ScimDiagnostic[],
+  options: { requireValue?: boolean; extraStringAttributes?: readonly string[] } = {}
+): void {
+  if (!hasOwn(resource, attribute)) return
+
+  const path = propertyPath('$', attribute)
+  const value = resource[attribute]
+  if (!Array.isArray(value)) {
+    diagnostic(
+      diagnostics,
+      'error',
+      path,
+      'multi_valued_attribute_type',
+      `${attribute} must be an array.`
+    )
+    return
+  }
+
+  let primaryCount = 0
+  value.forEach((item, index) => {
+    const itemPath = `${path}[${index}]`
+    if (!isObject(item)) {
+      diagnostic(
+        diagnostics,
+        'error',
+        itemPath,
+        'multi_valued_item_type',
+        `${attribute} entries must be objects.`
+      )
+      return
+    }
+
+    const stringAttributes = [
+      'value',
+      'display',
+      'type',
+      '$ref',
+      ...(options.extraStringAttributes ?? []),
+    ]
+    validateStringSubAttributes(item, stringAttributes, itemPath, diagnostics)
+
+    if (
+      options.requireValue &&
+      (!hasOwn(item, 'value') || (typeof item.value === 'string' && !item.value.trim()))
+    ) {
+      diagnostic(
+        diagnostics,
+        'error',
+        propertyPath(itemPath, 'value'),
+        'multi_valued_value_missing',
+        `${attribute} entries require a non-empty value.`
+      )
+    }
+
+    if (hasOwn(item, 'primary')) {
+      if (typeof item.primary !== 'boolean') {
+        diagnostic(
+          diagnostics,
+          'error',
+          propertyPath(itemPath, 'primary'),
+          'primary_type',
+          'primary must be a boolean.'
+        )
+      } else if (item.primary) {
+        primaryCount += 1
+      }
+    }
+  })
+
+  if (primaryCount > 1) {
+    diagnostic(
+      diagnostics,
+      'error',
+      path,
+      'multiple_primary_values',
+      `${attribute} may contain at most one entry with primary set to true.`
+    )
+  }
+}
+
+function validateMeta(
+  resource: ScimObject,
+  resourceType: ScimResourceType,
+  diagnostics: ScimDiagnostic[]
+): void {
+  if (!hasOwn(resource, 'meta')) return
+
+  const meta = resource.meta
+  if (!isObject(meta)) {
+    diagnostic(diagnostics, 'error', '$.meta', 'meta_type', 'meta must be an object.')
+    return
+  }
+
+  validateStringSubAttributes(
+    meta,
+    ['resourceType', 'created', 'lastModified', 'location', 'version'],
+    '$.meta',
+    diagnostics
+  )
+
+  for (const dateAttribute of ['created', 'lastModified'] as const) {
+    const dateValue = meta[dateAttribute]
+    if (typeof dateValue === 'string' && Number.isNaN(Date.parse(dateValue))) {
+      diagnostic(
+        diagnostics,
+        'warning',
+        propertyPath('$.meta', dateAttribute),
+        'date_time_format',
+        `${dateAttribute} should be an RFC 3339 date-time.`
+      )
+    }
+  }
+
+  if (
+    resourceType !== 'Unknown' &&
+    typeof meta.resourceType === 'string' &&
+    meta.resourceType !== resourceType
+  ) {
+    diagnostic(
+      diagnostics,
+      'warning',
+      '$.meta.resourceType',
+      'meta_resource_type_mismatch',
+      `meta.resourceType is ${meta.resourceType}, but schemas identify a ${resourceType}.`
+    )
+  }
+}
+
+function validateEnterpriseExtension(
+  resource: ScimObject,
+  schemas: readonly string[],
+  resourceType: ScimResourceType,
+  diagnostics: ScimDiagnostic[]
+): void {
+  const declared = schemas.includes(SCIM_ENTERPRISE_USER_SCHEMA)
+  const present = hasOwn(resource, SCIM_ENTERPRISE_USER_SCHEMA)
+  const extensionPath = propertyPath('$', SCIM_ENTERPRISE_USER_SCHEMA)
+
+  if (declared && !present) {
+    diagnostic(
+      diagnostics,
+      'error',
+      extensionPath,
+      'extension_value_missing',
+      'The Enterprise User schema is declared, but its extension object is missing.'
+    )
+  }
+
+  if (present && !declared) {
+    diagnostic(
+      diagnostics,
+      'error',
+      '$.schemas',
+      'extension_schema_missing',
+      'The Enterprise User extension is present, but its schema URN is not declared.'
+    )
+  }
+
+  if ((declared || present) && resourceType !== 'User') {
+    diagnostic(
+      diagnostics,
+      'error',
+      extensionPath,
+      'extension_resource_type',
+      'The Enterprise User extension can only be used with User resources.'
+    )
+  }
+
+  if (!present) return
+
+  const extension = resource[SCIM_ENTERPRISE_USER_SCHEMA]
+  if (!isObject(extension)) {
+    diagnostic(
+      diagnostics,
+      'error',
+      extensionPath,
+      'extension_type',
+      'The Enterprise User extension must be an object.'
+    )
+    return
+  }
+
+  validateStringSubAttributes(extension, ENTERPRISE_STRING_ATTRIBUTES, extensionPath, diagnostics)
+
+  if (hasOwn(extension, 'manager')) {
+    const managerPath = propertyPath(extensionPath, 'manager')
+    if (!isObject(extension.manager)) {
+      diagnostic(
+        diagnostics,
+        'error',
+        managerPath,
+        'complex_attribute_type',
+        'manager must be an object.'
+      )
+    } else {
+      validateStringSubAttributes(
+        extension.manager,
+        ['value', '$ref', 'displayName'],
+        managerPath,
+        diagnostics
+      )
+    }
+  }
+}
+
+function validateExtensionConsistency(
+  resource: ScimObject,
+  schemas: readonly string[],
+  diagnostics: ScimDiagnostic[]
+): void {
+  for (const [attribute, value] of Object.entries(resource)) {
+    if (!attribute.startsWith('urn:') || attribute === SCIM_ENTERPRISE_USER_SCHEMA) continue
+
+    const path = propertyPath('$', attribute)
+    if (!schemas.includes(attribute)) {
+      diagnostic(
+        diagnostics,
+        'error',
+        '$.schemas',
+        'extension_schema_missing',
+        `Extension ${attribute} is present, but its schema URN is not declared.`
+      )
+    }
+    if (!isObject(value)) {
+      diagnostic(
+        diagnostics,
+        'error',
+        path,
+        'extension_type',
+        `Extension ${attribute} must be an object.`
+      )
+    }
+  }
+
+  for (const schema of schemas) {
+    if (
+      schema !== SCIM_USER_SCHEMA &&
+      schema !== SCIM_GROUP_SCHEMA &&
+      schema !== SCIM_ENTERPRISE_USER_SCHEMA &&
+      !hasOwn(resource, schema)
+    ) {
+      diagnostic(
+        diagnostics,
+        'error',
+        propertyPath('$', schema),
+        'extension_value_missing',
+        `Extension schema ${schema} is declared, but its extension object is missing.`
+      )
+    }
+  }
+}
+
+function parseSchemas(resource: ScimObject, diagnostics: ScimDiagnostic[]): string[] {
+  if (!hasOwn(resource, 'schemas')) {
+    diagnostic(diagnostics, 'error', '$.schemas', 'schemas_missing', 'schemas is required.')
+    return []
+  }
+
+  if (!Array.isArray(resource.schemas)) {
+    diagnostic(
+      diagnostics,
+      'error',
+      '$.schemas',
+      'schemas_type',
+      'schemas must be an array of schema URN strings.'
+    )
+    return []
+  }
+
+  if (resource.schemas.length === 0) {
+    diagnostic(
+      diagnostics,
+      'error',
+      '$.schemas',
+      'schemas_empty',
+      'schemas must contain at least one schema URN.'
+    )
+  }
+
+  const schemas: string[] = []
+  const seen = new Set<string>()
+  resource.schemas.forEach((schema, index) => {
+    const path = `$.schemas[${index}]`
+    if (typeof schema !== 'string' || !schema.trim()) {
+      diagnostic(
+        diagnostics,
+        'error',
+        path,
+        'schema_uri_type',
+        'Each schemas entry must be a non-empty string.'
+      )
+      return
+    }
+
+    const normalized = schema.trim()
+    schemas.push(normalized)
+    if (seen.has(normalized)) {
+      diagnostic(
+        diagnostics,
+        'warning',
+        path,
+        'duplicate_schema',
+        `Schema ${normalized} is declared more than once.`
+      )
+    }
+    seen.add(normalized)
+  })
+
+  return schemas
+}
+
+function determineResourceType(
+  schemas: readonly string[],
+  diagnostics: ScimDiagnostic[]
+): ScimResourceType {
+  const hasUser = schemas.includes(SCIM_USER_SCHEMA)
+  const hasGroup = schemas.includes(SCIM_GROUP_SCHEMA)
+
+  if (hasUser && hasGroup) {
+    diagnostic(
+      diagnostics,
+      'error',
+      '$.schemas',
+      'multiple_core_schemas',
+      'A resource cannot declare both the core User and Group schemas.'
+    )
+    return 'Unknown'
+  }
+
+  if (!hasUser && !hasGroup) {
+    diagnostic(
+      diagnostics,
+      'error',
+      '$.schemas',
+      'core_schema_missing',
+      'schemas must declare either the core User or Group schema.'
+    )
+    return 'Unknown'
+  }
+
+  const resourceType: ScimResourceType = hasUser ? 'User' : 'Group'
+  diagnostic(
+    diagnostics,
+    'info',
+    '$.schemas',
+    'resource_type_detected',
+    `Detected a SCIM ${resourceType} resource.`
+  )
+  return resourceType
+}
+
+function validateUser(resource: ScimObject, diagnostics: ScimDiagnostic[]): void {
+  validateRequiredString(resource, 'userName', diagnostics)
+
+  for (const attribute of COMMON_STRING_ATTRIBUTES) {
+    validateOptionalString(resource, attribute, '$', diagnostics)
+  }
+  for (const attribute of USER_STRING_ATTRIBUTES) {
+    validateOptionalString(resource, attribute, '$', diagnostics)
+  }
+
+  if (hasOwn(resource, 'active') && typeof resource.active !== 'boolean') {
+    diagnostic(diagnostics, 'error', '$.active', 'attribute_type', 'active must be a boolean.')
+  }
+
+  validateComplexAttribute(resource, 'name', NAME_SUB_ATTRIBUTES, diagnostics)
+  for (const attribute of USER_MULTI_VALUE_ATTRIBUTES) {
+    validateMultiValuedAttribute(resource, attribute, diagnostics, {
+      extraStringAttributes: attribute === 'addresses' ? ADDRESS_SUB_ATTRIBUTES : undefined,
+    })
+  }
+}
+
+function validateGroup(resource: ScimObject, diagnostics: ScimDiagnostic[]): void {
+  validateRequiredString(resource, 'displayName', diagnostics)
+  for (const attribute of COMMON_STRING_ATTRIBUTES) {
+    validateOptionalString(resource, attribute, '$', diagnostics)
+  }
+  validateMultiValuedAttribute(resource, 'members', diagnostics, { requireValue: true })
+}
+
+/** Validate a SCIM User or Group resource represented as JSON text. */
+export function validateScimResource(input: string): ScimResourceValidationResult {
+  const diagnostics: ScimDiagnostic[] = []
+  if (!input.trim()) {
+    diagnostic(diagnostics, 'error', '$', 'empty_input', 'Enter a SCIM resource as JSON.')
+    return { valid: false, resourceType: 'Unknown', parsed: null, diagnostics }
+  }
+
+  let value: unknown
+  try {
+    value = JSON.parse(input)
+  } catch (error) {
+    const detail = error instanceof Error ? ` ${error.message}` : ''
+    diagnostic(diagnostics, 'error', '$', 'invalid_json', `Input is not valid JSON.${detail}`)
+    return { valid: false, resourceType: 'Unknown', parsed: null, diagnostics }
+  }
+
+  if (!isObject(value)) {
+    diagnostic(diagnostics, 'error', '$', 'resource_type', 'A SCIM resource must be a JSON object.')
+    return { valid: false, resourceType: 'Unknown', parsed: null, diagnostics }
+  }
+
+  const schemas = parseSchemas(value, diagnostics)
+  const resourceType = determineResourceType(schemas, diagnostics)
+
+  if (resourceType === 'User') validateUser(value, diagnostics)
+  if (resourceType === 'Group') validateGroup(value, diagnostics)
+
+  validateMeta(value, resourceType, diagnostics)
+  validateEnterpriseExtension(value, schemas, resourceType, diagnostics)
+  validateExtensionConsistency(value, schemas, diagnostics)
+
+  return {
+    valid: !diagnostics.some((item) => item.severity === 'error'),
+    resourceType,
+    parsed: value,
+    diagnostics,
+  }
+}

--- a/src/features/scim/utils/types.ts
+++ b/src/features/scim/utils/types.ts
@@ -1,0 +1,46 @@
+export type ScimDiagnosticSeverity = 'error' | 'warning' | 'info'
+
+export interface ScimDiagnostic {
+  severity: ScimDiagnosticSeverity
+  path: string
+  message: string
+  code: string
+}
+
+export type ScimResourceType = 'User' | 'Group' | 'Unknown'
+
+export interface ScimResourceValidationResult {
+  valid: boolean
+  resourceType: ScimResourceType
+  parsed: Record<string, unknown> | null
+  diagnostics: ScimDiagnostic[]
+}
+
+export type ScimPatchOperationName = 'add' | 'remove' | 'replace'
+
+export interface ScimPatchOperation {
+  op: ScimPatchOperationName
+  path?: string
+  value?: unknown
+}
+
+export type ScimPatchOperationInput =
+  | { op: 'add' | 'replace'; path?: string; value: unknown }
+  | { op: 'remove'; path: string; value?: never }
+
+export interface ScimPatchDocument {
+  schemas: string[]
+  Operations: ScimPatchOperation[]
+}
+
+export interface ScimPatchValidationResult {
+  valid: boolean
+  parsed: Record<string, unknown> | null
+  operations: ScimPatchOperation[]
+  diagnostics: ScimDiagnostic[]
+}
+
+export interface ScimPatchBuildResult {
+  document: ScimPatchDocument
+  json: string
+}

--- a/src/features/token-comparison/pages/index.tsx
+++ b/src/features/token-comparison/pages/index.tsx
@@ -1,0 +1,378 @@
+import { useMemo, useState } from 'react'
+import {
+  ArrowRightLeft,
+  Braces,
+  Eye,
+  EyeOff,
+  GitCompareArrows,
+  Info,
+  ShieldCheck,
+  Sparkles,
+  Trash2,
+} from 'lucide-react'
+import { PageContainer, PageHeader } from '@/components/page'
+import { CopyButton } from '@/components/common'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from '@/components/ui/empty'
+import { Field, FieldDescription, FieldError, FieldGroup, FieldLabel } from '@/components/ui/field'
+import { Item, ItemContent, ItemDescription, ItemGroup, ItemTitle } from '@/components/ui/item'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  compareTokens,
+  createExampleComparisonTokens,
+  decodeTokenForComparison,
+  type ClaimDifference,
+  type DifferenceKind,
+  type TokenMetadata,
+} from '../utils/token-comparison'
+
+const STATUS_VARIANTS: Record<DifferenceKind, 'default' | 'secondary' | 'destructive' | 'outline'> =
+  {
+    changed: 'default',
+    added: 'secondary',
+    removed: 'destructive',
+    unchanged: 'outline',
+  }
+
+function formatValue(value: unknown): string {
+  if (value === undefined) return '—'
+  if (typeof value === 'string') return value
+  return JSON.stringify(value, null, 2)
+}
+
+function formatTimestamp(value?: number): string {
+  return value === undefined ? 'Not present' : new Date(value * 1000).toLocaleString()
+}
+
+function formatDuration(value?: number): string {
+  if (value === undefined) return 'Not available'
+  const sign = value < 0 ? '−' : ''
+  const total = Math.abs(value)
+  const hours = Math.floor(total / 3600)
+  const minutes = Math.floor((total % 3600) / 60)
+  const seconds = total % 60
+  return `${sign}${hours ? `${hours}h ` : ''}${minutes ? `${minutes}m ` : ''}${seconds}s`.trim()
+}
+
+function ValueCell({ value, difference }: { value: unknown; difference: ClaimDifference }) {
+  const values = Array.isArray(value)
+    ? new Set(value.filter((item) => typeof item === 'string'))
+    : null
+
+  return (
+    <TableCell className="max-w-[22rem] whitespace-normal align-top">
+      <code className="break-all text-xs whitespace-pre-wrap">{formatValue(value)}</code>
+      {values && (difference.addedValues?.length || difference.removedValues?.length) ? (
+        <div className="mt-2 flex flex-wrap gap-1">
+          {difference.addedValues
+            ?.filter((item) => values.has(item))
+            .map((item) => (
+              <Badge key={`added-${item}`} variant="secondary">
+                + {item}
+              </Badge>
+            ))}
+          {difference.removedValues
+            ?.filter((item) => values.has(item))
+            .map((item) => (
+              <Badge key={`removed-${item}`} variant="destructive">
+                − {item}
+              </Badge>
+            ))}
+        </div>
+      ) : null}
+    </TableCell>
+  )
+}
+
+function MetadataColumn({ label, metadata }: { label: string; metadata: TokenMetadata }) {
+  return (
+    <Item>
+      <ItemContent className="min-w-0">
+        <ItemTitle>{label}</ItemTitle>
+        <ItemDescription className="break-all">
+          Issuer: {metadata.issuer ?? 'Not present'}
+        </ItemDescription>
+        <ItemDescription className="break-all">
+          Subject: {metadata.subject ?? 'Not present'}
+        </ItemDescription>
+        <ItemDescription>Issued: {formatTimestamp(metadata.issuedAt)}</ItemDescription>
+        <ItemDescription>Expires: {formatTimestamp(metadata.expiresAt)}</ItemDescription>
+        <ItemDescription>Lifetime: {formatDuration(metadata.lifetimeSeconds)}</ItemDescription>
+      </ItemContent>
+    </Item>
+  )
+}
+
+export default function TokenComparisonPage() {
+  const [leftToken, setLeftToken] = useState('')
+  const [rightToken, setRightToken] = useState('')
+  const [showUnchanged, setShowUnchanged] = useState(false)
+
+  const leftDecode = useMemo(
+    () => (leftToken.trim() ? decodeTokenForComparison(leftToken) : null),
+    [leftToken]
+  )
+  const rightDecode = useMemo(
+    () => (rightToken.trim() ? decodeTokenForComparison(rightToken) : null),
+    [rightToken]
+  )
+  const comparison = useMemo(() => {
+    if (!leftDecode?.ok || !rightDecode?.ok) return null
+    return compareTokens(leftToken, rightToken)
+  }, [leftDecode, leftToken, rightDecode, rightToken])
+
+  const visibleDifferences = useMemo(
+    () =>
+      comparison?.differences.filter(
+        (difference) => showUnchanged || difference.kind !== 'unchanged'
+      ) ?? [],
+    [comparison, showUnchanged]
+  )
+
+  const report = useMemo(
+    () =>
+      comparison
+        ? JSON.stringify(
+            {
+              warning: 'Decoded comparison only; signatures were not verified.',
+              counts: comparison.counts,
+              metadata: comparison.metadata,
+              differences: comparison.differences.filter((item) => item.kind !== 'unchanged'),
+            },
+            null,
+            2
+          )
+        : '',
+    [comparison]
+  )
+
+  const loadExample = () => {
+    const example = createExampleComparisonTokens()
+    setLeftToken(example.left)
+    setRightToken(example.right)
+  }
+
+  const swapTokens = () => {
+    setLeftToken(rightToken)
+    setRightToken(leftToken)
+  }
+
+  const clearTokens = () => {
+    setLeftToken('')
+    setRightToken('')
+    setShowUnchanged(false)
+  }
+
+  return (
+    <PageContainer maxWidth="full">
+      <PageHeader
+        title="Token Claims Diff"
+        description="Compare two JWTs side by side to pinpoint claim, scope, role, audience, and lifetime differences."
+        icon={GitCompareArrows}
+      />
+
+      <div className="flex flex-col gap-6" data-testid="token-comparison-root">
+        <Alert>
+          <ShieldCheck />
+          <AlertTitle>Local, ephemeral comparison</AlertTitle>
+          <AlertDescription>
+            This tool does not persist either token or send it over the network. Decoding is not
+            cryptographic verification; use Token Inspector when trust matters.
+          </AlertDescription>
+        </Alert>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Tokens to compare</CardTitle>
+            <CardDescription>
+              Paste compact JWTs from two environments, clients, sessions, or points in time.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <FieldGroup className="grid gap-5 lg:grid-cols-2">
+              <Field data-invalid={Boolean(leftDecode && !leftDecode.ok)}>
+                <FieldLabel htmlFor="token-comparison-left">Token A</FieldLabel>
+                <Textarea
+                  id="token-comparison-left"
+                  value={leftToken}
+                  onChange={(event) => setLeftToken(event.target.value)}
+                  placeholder="eyJhbGciOi..."
+                  className="min-h-44 font-mono text-xs"
+                  spellCheck={false}
+                  autoComplete="off"
+                  aria-invalid={Boolean(leftDecode && !leftDecode.ok)}
+                  data-testid="token-comparison-left"
+                />
+                <FieldDescription>Baseline or expected token.</FieldDescription>
+                {leftDecode && !leftDecode.ok ? <FieldError>{leftDecode.error}</FieldError> : null}
+              </Field>
+
+              <Field data-invalid={Boolean(rightDecode && !rightDecode.ok)}>
+                <FieldLabel htmlFor="token-comparison-right">Token B</FieldLabel>
+                <Textarea
+                  id="token-comparison-right"
+                  value={rightToken}
+                  onChange={(event) => setRightToken(event.target.value)}
+                  placeholder="eyJhbGciOi..."
+                  className="min-h-44 font-mono text-xs"
+                  spellCheck={false}
+                  autoComplete="off"
+                  aria-invalid={Boolean(rightDecode && !rightDecode.ok)}
+                  data-testid="token-comparison-right"
+                />
+                <FieldDescription>Observed or changed token.</FieldDescription>
+                {rightDecode && !rightDecode.ok ? (
+                  <FieldError>{rightDecode.error}</FieldError>
+                ) : null}
+              </Field>
+            </FieldGroup>
+          </CardContent>
+          <CardFooter className="flex-wrap gap-2">
+            <Button onClick={loadExample} data-testid="token-comparison-example">
+              <Sparkles data-icon="inline-start" />
+              Load example
+            </Button>
+            <Button variant="outline" onClick={swapTokens} disabled={!leftToken && !rightToken}>
+              <ArrowRightLeft data-icon="inline-start" />
+              Swap
+            </Button>
+            <Button variant="ghost" onClick={clearTokens} disabled={!leftToken && !rightToken}>
+              <Trash2 data-icon="inline-start" />
+              Clear
+            </Button>
+          </CardFooter>
+        </Card>
+
+        {comparison ? (
+          <>
+            <ItemGroup className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+              {(['changed', 'added', 'removed', 'unchanged'] as const).map((kind) => (
+                <Item key={kind}>
+                  <ItemContent>
+                    <ItemTitle className="capitalize">{kind}</ItemTitle>
+                    <ItemDescription>{comparison.counts[kind]} claim paths</ItemDescription>
+                  </ItemContent>
+                  <Badge variant={STATUS_VARIANTS[kind]}>{comparison.counts[kind]}</Badge>
+                </Item>
+              ))}
+            </ItemGroup>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Token timing and identity</CardTitle>
+                <CardDescription>
+                  Token B was issued {formatDuration(comparison.metadata.issuedAtDeltaSeconds)} from
+                  Token A and its lifetime changed by{' '}
+                  {formatDuration(comparison.metadata.lifetimeDeltaSeconds)}.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <ItemGroup className="grid gap-3 lg:grid-cols-2">
+                  <MetadataColumn label="Token A" metadata={comparison.metadata.left} />
+                  <MetadataColumn label="Token B" metadata={comparison.metadata.right} />
+                </ItemGroup>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="flex flex-col gap-1.5">
+                    <CardTitle>Claim differences</CardTitle>
+                    <CardDescription>
+                      Set-like claims are order-insensitive and show their added or removed values.
+                    </CardDescription>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      aria-pressed={showUnchanged}
+                      onClick={() => setShowUnchanged((current) => !current)}
+                    >
+                      {showUnchanged ? (
+                        <EyeOff data-icon="inline-start" />
+                      ) : (
+                        <Eye data-icon="inline-start" />
+                      )}
+                      {showUnchanged ? 'Hide unchanged' : 'Show unchanged'}
+                    </Button>
+                    <CopyButton text={report} copiedText="Report copied" />
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Path</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Token A</TableHead>
+                      <TableHead>Token B</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {visibleDifferences.map((difference) => (
+                      <TableRow key={`${difference.section}-${difference.path}`}>
+                        <TableCell className="whitespace-normal align-top">
+                          <Badge variant="outline" className="mb-2">
+                            {difference.section}
+                          </Badge>
+                          <div className="font-mono text-xs break-all">{difference.path}</div>
+                        </TableCell>
+                        <TableCell className="align-top">
+                          <Badge variant={STATUS_VARIANTS[difference.kind]}>
+                            {difference.kind}
+                          </Badge>
+                        </TableCell>
+                        <ValueCell value={difference.left} difference={difference} />
+                        <ValueCell value={difference.right} difference={difference} />
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </CardContent>
+            </Card>
+
+            <Alert>
+              <Info />
+              <AlertTitle>What this comparison does not prove</AlertTitle>
+              <AlertDescription>
+                Matching claims do not prove the tokens are authentic, intended for this app, or
+                safe to accept. Verify signatures, issuer, audience, and policy separately.
+              </AlertDescription>
+            </Alert>
+          </>
+        ) : (
+          <Empty>
+            <EmptyMedia variant="icon">
+              <Braces />
+            </EmptyMedia>
+            <EmptyTitle>Paste two JWTs to begin</EmptyTitle>
+            <EmptyDescription>
+              Load the safe example to see audience, scope, role, custom-claim, and timing drift.
+            </EmptyDescription>
+          </Empty>
+        )}
+      </div>
+    </PageContainer>
+  )
+}

--- a/src/features/token-comparison/utils/token-comparison.ts
+++ b/src/features/token-comparison/utils/token-comparison.ts
@@ -1,0 +1,306 @@
+import { decodeJWT, type DecodedJWT } from '@/lib/jwt/decode-token'
+
+export type DifferenceKind = 'added' | 'removed' | 'changed' | 'unchanged'
+
+export interface ClaimDifference {
+  section: 'header' | 'payload'
+  path: string
+  kind: DifferenceKind
+  left?: unknown
+  right?: unknown
+  addedValues?: string[]
+  removedValues?: string[]
+}
+
+export interface TokenMetadata {
+  issuer?: string
+  subject?: string
+  audiences: string[]
+  scopes: string[]
+  issuedAt?: number
+  expiresAt?: number
+  lifetimeSeconds?: number
+}
+
+export interface TokenComparisonResult {
+  left: DecodedJWT
+  right: DecodedJWT
+  differences: ClaimDifference[]
+  counts: Record<DifferenceKind, number>
+  metadata: {
+    left: TokenMetadata
+    right: TokenMetadata
+    issuedAtDeltaSeconds?: number
+    expiresAtDeltaSeconds?: number
+    lifetimeDeltaSeconds?: number
+  }
+}
+
+export type TokenDecodeResult = { ok: true; decoded: DecodedJWT } | { ok: false; error: string }
+
+const SET_LIKE_CLAIMS = new Set([
+  'aud',
+  'scope',
+  'scp',
+  'roles',
+  'groups',
+  'permissions',
+  'entitlements',
+])
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function stableValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stableValue)
+  }
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, stableValue(value[key])])
+    )
+  }
+  return value
+}
+
+function valuesEqual(left: unknown, right: unknown): boolean {
+  return JSON.stringify(stableValue(left)) === JSON.stringify(stableValue(right))
+}
+
+function normalizeStringSet(value: unknown, splitWhitespace: boolean): string[] | null {
+  const values = Array.isArray(value)
+    ? value
+    : typeof value === 'string'
+      ? splitWhitespace
+        ? value.split(/\s+/)
+        : [value]
+      : null
+
+  if (!values || values.some((entry) => typeof entry !== 'string')) {
+    return null
+  }
+
+  return [...new Set(values.map((entry) => entry.trim()).filter(Boolean))].sort()
+}
+
+function compareSetLikeClaim(
+  section: 'header' | 'payload',
+  path: string,
+  claimName: string,
+  left: unknown,
+  right: unknown
+): ClaimDifference | null {
+  if (section !== 'payload' || !SET_LIKE_CLAIMS.has(claimName)) {
+    return null
+  }
+
+  const splitWhitespace = claimName === 'scope' || claimName === 'scp'
+  const leftValues = normalizeStringSet(left, splitWhitespace)
+  const rightValues = normalizeStringSet(right, splitWhitespace)
+  if (!leftValues || !rightValues) {
+    return null
+  }
+
+  const leftSet = new Set(leftValues)
+  const rightSet = new Set(rightValues)
+  const addedValues = rightValues.filter((value) => !leftSet.has(value))
+  const removedValues = leftValues.filter((value) => !rightSet.has(value))
+
+  return {
+    section,
+    path,
+    kind: addedValues.length || removedValues.length ? 'changed' : 'unchanged',
+    left: leftValues,
+    right: rightValues,
+    addedValues,
+    removedValues,
+  }
+}
+
+function compareRecords(
+  section: 'header' | 'payload',
+  left: Record<string, unknown>,
+  right: Record<string, unknown>,
+  prefix = ''
+): ClaimDifference[] {
+  const keys = [...new Set([...Object.keys(left), ...Object.keys(right)])].sort()
+  const differences: ClaimDifference[] = []
+
+  for (const key of keys) {
+    const path = prefix ? `${prefix}.${key}` : key
+    const hasLeft = Object.prototype.hasOwnProperty.call(left, key)
+    const hasRight = Object.prototype.hasOwnProperty.call(right, key)
+
+    if (!hasLeft) {
+      differences.push({ section, path, kind: 'added', right: right[key] })
+      continue
+    }
+    if (!hasRight) {
+      differences.push({ section, path, kind: 'removed', left: left[key] })
+      continue
+    }
+
+    const leftValue = left[key]
+    const rightValue = right[key]
+    const setComparison = compareSetLikeClaim(section, path, key, leftValue, rightValue)
+    if (setComparison) {
+      differences.push(setComparison)
+      continue
+    }
+
+    if (isRecord(leftValue) && isRecord(rightValue)) {
+      differences.push(...compareRecords(section, leftValue, rightValue, path))
+      continue
+    }
+
+    differences.push({
+      section,
+      path,
+      kind: valuesEqual(leftValue, rightValue) ? 'unchanged' : 'changed',
+      left: leftValue,
+      right: rightValue,
+    })
+  }
+
+  return differences
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value ? value : undefined
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function getMetadata(payload: Record<string, unknown>): TokenMetadata {
+  const audiences = normalizeStringSet(payload.aud, false) ?? []
+  const scopes = [
+    ...(normalizeStringSet(payload.scope, true) ?? []),
+    ...(normalizeStringSet(payload.scp, true) ?? []),
+  ]
+  const issuedAt = readNumber(payload.iat)
+  const expiresAt = readNumber(payload.exp)
+
+  return {
+    issuer: readString(payload.iss),
+    subject: readString(payload.sub),
+    audiences,
+    scopes: [...new Set(scopes)].sort(),
+    issuedAt,
+    expiresAt,
+    lifetimeSeconds:
+      issuedAt !== undefined && expiresAt !== undefined ? expiresAt - issuedAt : undefined,
+  }
+}
+
+function subtractIfDefined(left?: number, right?: number): number | undefined {
+  return left !== undefined && right !== undefined ? right - left : undefined
+}
+
+export function decodeTokenForComparison(token: string): TokenDecodeResult {
+  if (!token.trim()) {
+    return { ok: false, error: 'Enter a compact JWT with three dot-separated segments.' }
+  }
+
+  const decoded = decodeJWT(token.trim())
+  if (!decoded) {
+    return { ok: false, error: 'This value is not a decodable compact JWT.' }
+  }
+
+  if (!isRecord(decoded.header)) {
+    return { ok: false, error: 'The JWT header must be a JSON object.' }
+  }
+  if (!isRecord(decoded.payload)) {
+    return { ok: false, error: 'The JWT payload must be a JSON object.' }
+  }
+
+  return { ok: true, decoded }
+}
+
+export function compareTokens(leftToken: string, rightToken: string): TokenComparisonResult {
+  const leftResult = decodeTokenForComparison(leftToken)
+  const rightResult = decodeTokenForComparison(rightToken)
+  if (!leftResult.ok || !rightResult.ok) {
+    throw new Error('Both values must be decodable compact JWTs before they can be compared.')
+  }
+
+  const differences = [
+    ...compareRecords('header', leftResult.decoded.header, rightResult.decoded.header),
+    ...compareRecords('payload', leftResult.decoded.payload, rightResult.decoded.payload),
+  ]
+  const counts: Record<DifferenceKind, number> = {
+    added: 0,
+    removed: 0,
+    changed: 0,
+    unchanged: 0,
+  }
+  for (const difference of differences) {
+    counts[difference.kind] += 1
+  }
+
+  const leftMetadata = getMetadata(leftResult.decoded.payload)
+  const rightMetadata = getMetadata(rightResult.decoded.payload)
+
+  return {
+    left: leftResult.decoded,
+    right: rightResult.decoded,
+    differences,
+    counts,
+    metadata: {
+      left: leftMetadata,
+      right: rightMetadata,
+      issuedAtDeltaSeconds: subtractIfDefined(leftMetadata.issuedAt, rightMetadata.issuedAt),
+      expiresAtDeltaSeconds: subtractIfDefined(leftMetadata.expiresAt, rightMetadata.expiresAt),
+      lifetimeDeltaSeconds: subtractIfDefined(
+        leftMetadata.lifetimeSeconds,
+        rightMetadata.lifetimeSeconds
+      ),
+    },
+  }
+}
+
+function encodeJsonSegment(value: Record<string, unknown>): string {
+  const bytes = new TextEncoder().encode(JSON.stringify(value))
+  let binary = ''
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+}
+
+export function createExampleComparisonTokens(now = Math.floor(Date.now() / 1000)): {
+  left: string
+  right: string
+} {
+  const header = { alg: 'RS256', typ: 'JWT', kid: 'demo-key-2026-01' }
+  const leftPayload = {
+    iss: 'https://id.example.com',
+    sub: 'user-2841',
+    aud: ['orders-api'],
+    scope: 'openid profile orders.read',
+    roles: ['support-agent'],
+    environment: 'staging',
+    iat: now,
+    exp: now + 3600,
+  }
+  const rightPayload = {
+    iss: 'https://id.example.com',
+    sub: 'user-2841',
+    aud: ['orders-api', 'billing-api'],
+    scope: 'openid profile orders.read billing.read',
+    roles: ['support-agent', 'billing-viewer'],
+    environment: 'production',
+    authentication_method: 'webauthn',
+    iat: now + 120,
+    exp: now + 1920,
+  }
+
+  return {
+    left: `${encodeJsonSegment(header)}.${encodeJsonSegment(leftPayload)}.example-signature-left`,
+    right: `${encodeJsonSegment(header)}.${encodeJsonSegment(rightPayload)}.example-signature-right`,
+  }
+}

--- a/src/features/tokenInspector/index.tsx
+++ b/src/features/tokenInspector/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import * as jose from 'jose'
 import { Card, CardContent } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -29,7 +29,6 @@ interface TokenInspectorProps {
 
 export function TokenInspector({ initialToken = null }: TokenInspectorProps) {
   const [token, setToken] = useState(initialToken || '')
-  const lastInitialTokenRef = useRef(initialToken)
   const [jwks, setJwks] = useState<jose.JSONWebKeySet | null>(null) // Holds the currently loaded JWKS
   const [activeTab, setActiveTab] = useState('payload')
   const [manualIssuerUrl, setManualIssuerUrl] = useState('') // Manual issuer URL override
@@ -70,13 +69,6 @@ export function TokenInspector({ initialToken = null }: TokenInspectorProps) {
       jwks_uri: selectedEnvironment.jwksEndpoint,
     }
   }, [issuerUrl, oidcConfig, selectedEnvironment])
-
-  if (initialToken !== lastInitialTokenRef.current) {
-    lastInitialTokenRef.current = initialToken
-    if (initialToken) {
-      setToken(initialToken)
-    }
-  }
 
   // Effect to decode token whenever the 'token' state changes
   useEffect(() => {

--- a/src/features/tokenInspector/pages/index.tsx
+++ b/src/features/tokenInspector/pages/index.tsx
@@ -14,7 +14,7 @@ export default function TokenInspectorPage() {
         description="Decode and inspect JWT tokens used in OAuth 2.0 and OpenID Connect protocols. Validate tokens, examine claims, and verify signatures."
         icon={KeyRound}
       />
-      <TokenInspector initialToken={urlToken} />
+      <TokenInspector key={urlToken ?? 'empty'} initialToken={urlToken} />
     </PageContainer>
   )
 }

--- a/src/features/totp/hooks/use-totp-codes.ts
+++ b/src/features/totp/hooks/use-totp-codes.ts
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react'
+import { generateTotp, type TotpAlgorithm } from '@/features/totp/utils'
+
+interface UseTotpCodesOptions {
+  secret?: string
+  algorithm: TotpAlgorithm
+  digits: number
+  period: number
+}
+
+export interface TotpCodeWindow {
+  previous: string
+  current: string
+  next: string
+  /** RFC 6238 moving-factor counter for the displayed current code. */
+  step: number
+  secondsRemaining: number
+  error?: string
+}
+
+interface GeneratedCodes extends Omit<TotpCodeWindow, 'secondsRemaining' | 'step'> {
+  key: string
+}
+
+export function useTotpCodes({
+  secret,
+  algorithm,
+  digits,
+  period,
+}: UseTotpCodesOptions): TotpCodeWindow | null {
+  const [now, setNow] = useState(() => Date.now())
+  const [codes, setCodes] = useState<GeneratedCodes | null>(null)
+
+  useEffect(() => {
+    const interval = window.setInterval(() => setNow(Date.now()), 1000)
+    return () => window.clearInterval(interval)
+  }, [])
+
+  const timestampSeconds = Math.floor(now / 1000)
+  const step = Math.floor(timestampSeconds / period)
+  const secondsRemaining = period - (timestampSeconds % period)
+  const generationKey = `${secret ?? ''}:${algorithm}:${digits}:${period}:${step}`
+
+  useEffect(() => {
+    if (!secret) {
+      return
+    }
+
+    let cancelled = false
+    const stepTimestamp = step * period
+    Promise.all(
+      [-1, 0, 1].map((delta) =>
+        generateTotp(secret, {
+          timestamp: stepTimestamp + delta * period,
+          algorithm,
+          digits,
+          period,
+        })
+      )
+    )
+      .then(([previous, current, next]) => {
+        if (!cancelled) setCodes({ key: generationKey, previous, current, next })
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) {
+          setCodes({
+            key: generationKey,
+            previous: '',
+            current: '',
+            next: '',
+            error: error instanceof Error ? error.message : 'Unable to generate TOTP codes.',
+          })
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [algorithm, digits, generationKey, period, secret, step])
+
+  if (!secret || !codes || codes.key !== generationKey) return null
+
+  return {
+    previous: codes.previous,
+    current: codes.current,
+    next: codes.next,
+    step,
+    secondsRemaining,
+    ...(codes.error ? { error: codes.error } : {}),
+  }
+}

--- a/src/features/totp/pages/index.tsx
+++ b/src/features/totp/pages/index.tsx
@@ -1,0 +1,518 @@
+import { useMemo, useState } from 'react'
+import {
+  CheckCircle2,
+  Clock3,
+  Eye,
+  EyeOff,
+  KeyRound,
+  RefreshCw,
+  ShieldCheck,
+  Sparkles,
+  Trash2,
+  XCircle,
+} from 'lucide-react'
+import { PageContainer, PageHeader } from '@/components/page'
+import { CopyButton } from '@/components/common'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from '@/components/ui/empty'
+import { Field, FieldDescription, FieldError, FieldGroup, FieldLabel } from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from '@/components/ui/input-group'
+import { Item, ItemContent, ItemDescription, ItemGroup, ItemTitle } from '@/components/ui/item'
+import { Progress } from '@/components/ui/progress'
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useTotpCodes } from '@/features/totp/hooks/use-totp-codes'
+import {
+  generateBase32Secret,
+  normalizeBase32,
+  parseOtpauthUri,
+  verifyTotp,
+  type OtpauthTotpConfig,
+  type TotpAlgorithm,
+  type TotpVerificationResult,
+} from '@/features/totp/utils'
+
+interface ResolvedInput {
+  secret?: string
+  parsed?: OtpauthTotpConfig
+  error?: string
+}
+
+interface StoredVerification {
+  key: string
+  result: TotpVerificationResult
+}
+
+interface VerificationKeyInput {
+  secret: string
+  algorithm: TotpAlgorithm
+  digits: number
+  period: number
+  candidateCode: string
+  driftWindow: number
+  step: number | null
+}
+
+export function buildTotpVerificationKey({
+  secret,
+  algorithm,
+  digits,
+  period,
+  candidateCode,
+  driftWindow,
+  step,
+}: VerificationKeyInput): string {
+  return JSON.stringify([secret, algorithm, digits, period, candidateCode, driftWindow, step])
+}
+
+function resolveSecretInput(input: string): ResolvedInput {
+  if (!input.trim()) return {}
+  try {
+    if (input.trim().toLowerCase().startsWith('otpauth://')) {
+      const parsed = parseOtpauthUri(input)
+      return { secret: parsed.secret, parsed }
+    }
+    return { secret: normalizeBase32(input) }
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : 'Invalid TOTP input.' }
+  }
+}
+
+export default function TotpDebuggerPage() {
+  const [secretInput, setSecretInput] = useState('')
+  const [showSecret, setShowSecret] = useState(false)
+  const [algorithm, setAlgorithm] = useState<TotpAlgorithm>('SHA1')
+  const [digits, setDigits] = useState(6)
+  const [period, setPeriod] = useState(30)
+  const [candidateCode, setCandidateCode] = useState('')
+  const [driftWindow, setDriftWindow] = useState(1)
+  const [verification, setVerification] = useState<StoredVerification | null>(null)
+  const [isVerifying, setIsVerifying] = useState(false)
+
+  const resolved = useMemo(() => resolveSecretInput(secretInput), [secretInput])
+  const effectiveAlgorithm = resolved.parsed?.algorithm ?? algorithm
+  const effectiveDigits = resolved.parsed?.digits ?? digits
+  const effectivePeriod = resolved.parsed?.period ?? period
+  const codes = useTotpCodes({
+    secret: resolved.secret,
+    algorithm: effectiveAlgorithm,
+    digits: effectiveDigits,
+    period: effectivePeriod,
+  })
+  const verificationKey = buildTotpVerificationKey({
+    secret: resolved.secret ?? '',
+    algorithm: effectiveAlgorithm,
+    digits: effectiveDigits,
+    period: effectivePeriod,
+    candidateCode,
+    driftWindow,
+    step: codes?.step ?? null,
+  })
+  const visibleVerification = verification?.key === verificationKey ? verification.result : null
+
+  const loadExample = () => {
+    setSecretInput('JBSWY3DPEHPK3PXP')
+    setAlgorithm('SHA1')
+    setDigits(6)
+    setPeriod(30)
+    setCandidateCode('')
+    setVerification(null)
+  }
+
+  const generateSecret = () => {
+    setSecretInput(generateBase32Secret())
+    setCandidateCode('')
+    setVerification(null)
+  }
+
+  const clear = () => {
+    setSecretInput('')
+    setCandidateCode('')
+    setVerification(null)
+    setShowSecret(false)
+  }
+
+  const verifyCandidate = async () => {
+    if (!resolved.secret || !codes) return
+    setIsVerifying(true)
+    try {
+      const result = await verifyTotp(candidateCode, resolved.secret, {
+        algorithm: effectiveAlgorithm,
+        digits: effectiveDigits,
+        period: effectivePeriod,
+        driftWindow,
+        timestamp: codes.step * effectivePeriod,
+      })
+      setVerification({ key: verificationKey, result })
+    } finally {
+      setIsVerifying(false)
+    }
+  }
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="TOTP Debugger"
+        description="Generate RFC 6238 codes, inspect otpauth settings, and identify time-step drift without exposing the shared secret."
+        icon={Clock3}
+      />
+
+      <div className="flex flex-col gap-6" data-testid="totp-debugger-root">
+        <Alert>
+          <ShieldCheck />
+          <AlertTitle>Secret-safe by design</AlertTitle>
+          <AlertDescription>
+            Seeds are processed only in memory, never persisted, logged, placed in a URL, or sent
+            over the network. Use test credentials whenever possible.
+          </AlertDescription>
+        </Alert>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Authenticator configuration</CardTitle>
+            <CardDescription>
+              Paste a Base32 secret or a complete <code>otpauth://totp</code> URI. URI parameters
+              override the manual algorithm, digits, and period controls.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <FieldGroup>
+              <Field data-invalid={Boolean(resolved.error)}>
+                <FieldLabel htmlFor="totp-secret-input">Base32 secret or otpauth URI</FieldLabel>
+                <InputGroup>
+                  <InputGroupInput
+                    id="totp-secret-input"
+                    type={showSecret ? 'text' : 'password'}
+                    value={secretInput}
+                    onChange={(event) => setSecretInput(event.target.value)}
+                    placeholder="JBSWY3DPEHPK3PXP"
+                    autoComplete="off"
+                    spellCheck={false}
+                    aria-invalid={Boolean(resolved.error)}
+                    data-testid="totp-secret-input"
+                  />
+                  <InputGroupAddon align="inline-end" className="p-0">
+                    <InputGroupButton
+                      size="icon"
+                      aria-label={showSecret ? 'Hide TOTP secret' : 'Show TOTP secret'}
+                      onClick={() => setShowSecret((current) => !current)}
+                    >
+                      {showSecret ? <EyeOff aria-hidden="true" /> : <Eye aria-hidden="true" />}
+                    </InputGroupButton>
+                  </InputGroupAddon>
+                </InputGroup>
+                <FieldDescription>
+                  Whitespace in Base32 is ignored. The field remains masked unless you reveal it.
+                </FieldDescription>
+                {resolved.error ? <FieldError>{resolved.error}</FieldError> : null}
+              </Field>
+
+              <div className="grid gap-5 sm:grid-cols-3">
+                <Field data-disabled={Boolean(resolved.parsed)}>
+                  <FieldLabel htmlFor="totp-algorithm">Algorithm</FieldLabel>
+                  <Select
+                    value={effectiveAlgorithm}
+                    onValueChange={(value) => setAlgorithm(value as TotpAlgorithm)}
+                    disabled={Boolean(resolved.parsed)}
+                  >
+                    <SelectTrigger id="totp-algorithm" className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectGroup>
+                        <SelectItem value="SHA1">SHA-1</SelectItem>
+                        <SelectItem value="SHA256">SHA-256</SelectItem>
+                        <SelectItem value="SHA512">SHA-512</SelectItem>
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                </Field>
+
+                <Field data-disabled={Boolean(resolved.parsed)}>
+                  <FieldLabel htmlFor="totp-digits">Digits</FieldLabel>
+                  {resolved.parsed ? (
+                    <>
+                      <Input
+                        id="totp-digits"
+                        value={`${effectiveDigits} digit${effectiveDigits === 1 ? '' : 's'}`}
+                        readOnly
+                        aria-readonly="true"
+                        className="bg-muted"
+                        data-testid="totp-effective-digits"
+                      />
+                      <FieldDescription>Read from the otpauth URI.</FieldDescription>
+                    </>
+                  ) : (
+                    <Select
+                      value={String(effectiveDigits)}
+                      onValueChange={(value) => setDigits(Number(value))}
+                    >
+                      <SelectTrigger id="totp-digits" className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectGroup>
+                          <SelectItem value="6">6 digits</SelectItem>
+                          <SelectItem value="8">8 digits</SelectItem>
+                        </SelectGroup>
+                      </SelectContent>
+                    </Select>
+                  )}
+                </Field>
+
+                <Field data-disabled={Boolean(resolved.parsed)}>
+                  <FieldLabel htmlFor="totp-period">Period</FieldLabel>
+                  {resolved.parsed ? (
+                    <>
+                      <Input
+                        id="totp-period"
+                        value={`${effectivePeriod} second${effectivePeriod === 1 ? '' : 's'}`}
+                        readOnly
+                        aria-readonly="true"
+                        className="bg-muted"
+                        data-testid="totp-effective-period"
+                      />
+                      <FieldDescription>Read from the otpauth URI.</FieldDescription>
+                    </>
+                  ) : (
+                    <Select
+                      value={String(effectivePeriod)}
+                      onValueChange={(value) => setPeriod(Number(value))}
+                    >
+                      <SelectTrigger id="totp-period" className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectGroup>
+                          <SelectItem value="30">30 seconds</SelectItem>
+                          <SelectItem value="60">60 seconds</SelectItem>
+                        </SelectGroup>
+                      </SelectContent>
+                    </Select>
+                  )}
+                </Field>
+              </div>
+            </FieldGroup>
+          </CardContent>
+          <CardFooter className="flex-wrap gap-2">
+            <Button onClick={loadExample} data-testid="totp-example">
+              <Sparkles data-icon="inline-start" />
+              Load test secret
+            </Button>
+            <Button variant="outline" onClick={generateSecret}>
+              <RefreshCw data-icon="inline-start" />
+              Generate random secret
+            </Button>
+            <Button variant="ghost" onClick={clear} disabled={!secretInput}>
+              <Trash2 data-icon="inline-start" />
+              Clear
+            </Button>
+          </CardFooter>
+        </Card>
+
+        {resolved.parsed ? (
+          <ItemGroup className="grid gap-3 sm:grid-cols-2">
+            <Item>
+              <ItemContent>
+                <ItemTitle>Issuer</ItemTitle>
+                <ItemDescription>{resolved.parsed.issuer ?? 'Not supplied'}</ItemDescription>
+              </ItemContent>
+            </Item>
+            <Item>
+              <ItemContent>
+                <ItemTitle>Account</ItemTitle>
+                <ItemDescription className="break-all">
+                  {resolved.parsed.accountName}
+                </ItemDescription>
+              </ItemContent>
+            </Item>
+          </ItemGroup>
+        ) : null}
+
+        {resolved.secret && codes && !codes.error ? (
+          <>
+            <Card>
+              <CardHeader>
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="flex flex-col gap-1.5">
+                    <CardTitle>Current code</CardTitle>
+                    <CardDescription>
+                      {effectiveAlgorithm} · {effectiveDigits} digits · {effectivePeriod}-second
+                      period
+                    </CardDescription>
+                  </div>
+                  <CopyButton text={codes.current} copiedText="Code copied" />
+                </div>
+              </CardHeader>
+              <CardContent className="flex flex-col gap-5">
+                <div
+                  className="text-center font-mono text-4xl font-semibold tracking-[0.3em] sm:text-5xl"
+                  data-testid="totp-current-code"
+                >
+                  {codes.current}
+                </div>
+                <Field>
+                  <div className="flex items-center justify-between gap-3">
+                    <FieldLabel htmlFor="totp-period-progress">Time remaining</FieldLabel>
+                    <span className="text-sm text-muted-foreground">{codes.secondsRemaining}s</span>
+                  </div>
+                  <Progress
+                    id="totp-period-progress"
+                    value={(codes.secondsRemaining / effectivePeriod) * 100}
+                    aria-label={`${codes.secondsRemaining} seconds remaining`}
+                  />
+                </Field>
+              </CardContent>
+            </Card>
+
+            <ItemGroup className="grid gap-3 sm:grid-cols-3">
+              <Item>
+                <ItemContent>
+                  <ItemTitle>Previous window</ItemTitle>
+                  <ItemDescription className="font-mono text-lg tracking-widest">
+                    {codes.previous}
+                  </ItemDescription>
+                </ItemContent>
+                <Badge variant="outline">−1</Badge>
+              </Item>
+              <Item>
+                <ItemContent>
+                  <ItemTitle>Current window</ItemTitle>
+                  <ItemDescription className="font-mono text-lg tracking-widest">
+                    {codes.current}
+                  </ItemDescription>
+                </ItemContent>
+                <Badge>0</Badge>
+              </Item>
+              <Item>
+                <ItemContent>
+                  <ItemTitle>Next window</ItemTitle>
+                  <ItemDescription className="font-mono text-lg tracking-widest">
+                    {codes.next}
+                  </ItemDescription>
+                </ItemContent>
+                <Badge variant="outline">+1</Badge>
+              </Item>
+            </ItemGroup>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Verify a candidate code</CardTitle>
+                <CardDescription>
+                  Search adjacent time steps to distinguish a bad code from clock drift.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <FieldGroup className="grid gap-5 sm:grid-cols-[1fr_12rem]">
+                  <Field>
+                    <FieldLabel htmlFor="totp-candidate-code">Candidate code</FieldLabel>
+                    <Input
+                      id="totp-candidate-code"
+                      value={candidateCode}
+                      onChange={(event) => setCandidateCode(event.target.value.replace(/\D/g, ''))}
+                      inputMode="numeric"
+                      maxLength={effectiveDigits}
+                      placeholder={'0'.repeat(effectiveDigits)}
+                      className="font-mono tracking-widest"
+                      data-testid="totp-candidate-code"
+                    />
+                  </Field>
+                  <Field>
+                    <FieldLabel htmlFor="totp-drift-window">Drift window</FieldLabel>
+                    <Select
+                      value={String(driftWindow)}
+                      onValueChange={(value) => setDriftWindow(Number(value))}
+                    >
+                      <SelectTrigger id="totp-drift-window" className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectGroup>
+                          <SelectItem value="0">Current only</SelectItem>
+                          <SelectItem value="1">±1 step</SelectItem>
+                          <SelectItem value="2">±2 steps</SelectItem>
+                        </SelectGroup>
+                      </SelectContent>
+                    </Select>
+                  </Field>
+                </FieldGroup>
+              </CardContent>
+              <CardFooter className="flex-wrap gap-3">
+                <Button
+                  onClick={verifyCandidate}
+                  disabled={candidateCode.length !== effectiveDigits || isVerifying}
+                  data-testid="totp-verify"
+                >
+                  <KeyRound data-icon="inline-start" />
+                  Verify code
+                </Button>
+                {visibleVerification ? (
+                  <Badge variant={visibleVerification.valid ? 'default' : 'destructive'}>
+                    {visibleVerification.valid
+                      ? `Valid at step ${visibleVerification.delta === 0 ? '0' : visibleVerification.delta}`
+                      : 'No match in window'}
+                  </Badge>
+                ) : null}
+              </CardFooter>
+            </Card>
+
+            {visibleVerification ? (
+              <Alert variant={visibleVerification.valid ? 'default' : 'destructive'}>
+                {visibleVerification.valid ? <CheckCircle2 /> : <XCircle />}
+                <AlertTitle>
+                  {visibleVerification.valid ? 'Candidate verified' : 'Candidate rejected'}
+                </AlertTitle>
+                <AlertDescription>
+                  {visibleVerification.valid
+                    ? visibleVerification.delta === 0
+                      ? 'The code matches the current time step.'
+                      : `The code matches time-step offset ${visibleVerification.delta}. Check clock synchronization.`
+                    : `No code matched within ±${driftWindow} time step${driftWindow === 1 ? '' : 's'}.`}
+                </AlertDescription>
+              </Alert>
+            ) : null}
+          </>
+        ) : resolved.secret && codes?.error ? (
+          <Alert variant="destructive">
+            <XCircle />
+            <AlertTitle>Unable to generate codes</AlertTitle>
+            <AlertDescription>{codes.error}</AlertDescription>
+          </Alert>
+        ) : (
+          <Empty>
+            <EmptyMedia variant="icon">
+              <Clock3 />
+            </EmptyMedia>
+            <EmptyTitle>Add a TOTP test secret</EmptyTitle>
+            <EmptyDescription>
+              Load the non-production example to see current and adjacent codes, countdown timing,
+              otpauth parsing, and drift-aware verification.
+            </EmptyDescription>
+          </Empty>
+        )}
+      </div>
+    </PageContainer>
+  )
+}

--- a/src/features/totp/utils/index.ts
+++ b/src/features/totp/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './totp'

--- a/src/features/totp/utils/totp.ts
+++ b/src/features/totp/utils/totp.ts
@@ -1,0 +1,560 @@
+const BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'
+const BASE32_VALUES = new Map(
+  Array.from(BASE32_ALPHABET, (character, index) => [character, index] as const)
+)
+
+const DEFAULT_ALGORITHM = 'SHA1' as const
+const DEFAULT_DIGITS = 6
+const DEFAULT_PERIOD = 30
+const DEFAULT_SECRET_BYTES = 20
+const MAX_DRIFT_WINDOW = 100
+
+export type TotpAlgorithm = 'SHA1' | 'SHA256' | 'SHA512'
+export type TotpSecret = string | Uint8Array
+
+export interface TotpOptions {
+  /**
+   * Unix time in seconds. JavaScript millisecond timestamps such as Date.now()
+   * and Date instances are also accepted for convenience.
+   */
+  timestamp?: number | Date
+  /** Time-step duration in seconds. */
+  period?: number
+  /** Number of decimal digits in the generated code. */
+  digits?: number
+  algorithm?: TotpAlgorithm
+}
+
+export interface VerifyTotpOptions extends TotpOptions {
+  /** Number of time steps to inspect on either side of the requested timestamp. */
+  window?: number
+  /** More descriptive alias for window. */
+  driftWindow?: number
+}
+
+export interface TotpVerificationResult {
+  valid: boolean
+  /** Matching offset in time steps. Null when no code matched. */
+  delta: number | null
+}
+
+export interface OtpauthTotpConfig {
+  type: 'totp'
+  accountName: string
+  issuer?: string
+  secret: string
+  algorithm: TotpAlgorithm
+  digits: number
+  period: number
+}
+
+export interface BuildOtpauthUriOptions {
+  accountName: string
+  issuer?: string
+  secret: string
+  algorithm?: TotpAlgorithm
+  digits?: number
+  period?: number
+}
+
+interface ResolvedTotpOptions {
+  timestampSeconds: number
+  period: number
+  digits: number
+  algorithm: TotpAlgorithm
+}
+
+const BASE32_REMAINDER_PADDING: Readonly<Record<number, number>> = {
+  0: 0,
+  2: 6,
+  4: 4,
+  5: 3,
+  7: 1,
+}
+
+const BASE32_REMAINDER_UNUSED_BITS: Readonly<Record<number, number>> = {
+  0: 0,
+  2: 2,
+  4: 4,
+  5: 1,
+  7: 3,
+}
+
+/**
+ * Normalizes an RFC 4648 Base32 value to uppercase, unpadded form.
+ * ASCII/Unicode whitespace is ignored, while malformed padding, characters,
+ * lengths, and non-zero trailing bits are rejected.
+ */
+export function normalizeBase32(value: string): string {
+  if (typeof value !== 'string') {
+    throw new TypeError('Base32 value must be a string')
+  }
+
+  const compact = value.replace(/\s/g, '').toUpperCase()
+  if (!compact) {
+    throw new Error('Base32 value is required')
+  }
+
+  const paddingStart = compact.indexOf('=')
+  const unpadded = paddingStart === -1 ? compact : compact.slice(0, paddingStart)
+  const padding = paddingStart === -1 ? '' : compact.slice(paddingStart)
+
+  if (padding && !/^=+$/.test(padding)) {
+    throw new Error('Base32 padding must appear only at the end')
+  }
+
+  if (!/^[A-Z2-7]+$/.test(unpadded)) {
+    throw new Error('Base32 value contains invalid characters')
+  }
+
+  const remainder = unpadded.length % 8
+  const expectedPadding = BASE32_REMAINDER_PADDING[remainder]
+  if (expectedPadding === undefined) {
+    throw new Error('Base32 value has an invalid length')
+  }
+
+  if (padding) {
+    if (compact.length % 8 !== 0 || padding.length !== expectedPadding || expectedPadding === 0) {
+      throw new Error('Base32 value has invalid padding')
+    }
+  }
+
+  const unusedBits = BASE32_REMAINDER_UNUSED_BITS[remainder] ?? 0
+  if (unusedBits > 0) {
+    const finalValue = BASE32_VALUES.get(unpadded[unpadded.length - 1]!)
+    if (finalValue === undefined || (finalValue & (2 ** unusedBits - 1)) !== 0) {
+      throw new Error('Base32 value has non-zero trailing bits')
+    }
+  }
+
+  return unpadded
+}
+
+/** Encodes bytes as uppercase, unpadded RFC 4648 Base32. */
+export function encodeBase32(bytes: Uint8Array): string {
+  if (!(bytes instanceof Uint8Array)) {
+    throw new TypeError('Base32 input must be a Uint8Array')
+  }
+
+  let accumulator = 0
+  let availableBits = 0
+  let encoded = ''
+
+  for (const byte of bytes) {
+    accumulator = (accumulator << 8) | byte
+    availableBits += 8
+
+    while (availableBits >= 5) {
+      availableBits -= 5
+      encoded += BASE32_ALPHABET[(accumulator >>> availableBits) & 0x1f]
+      accumulator &= 2 ** availableBits - 1
+    }
+  }
+
+  if (availableBits > 0) {
+    encoded += BASE32_ALPHABET[(accumulator << (5 - availableBits)) & 0x1f]
+  }
+
+  return encoded
+}
+
+/** Decodes padded or unpadded RFC 4648 Base32 into bytes. */
+export function decodeBase32(value: string): Uint8Array<ArrayBuffer> {
+  const normalized = normalizeBase32(value)
+  const outputLength = Math.floor((normalized.length * 5) / 8)
+  const decoded = new Uint8Array(outputLength)
+
+  let accumulator = 0
+  let availableBits = 0
+  let outputIndex = 0
+
+  for (const character of normalized) {
+    const characterValue = BASE32_VALUES.get(character)
+    if (characterValue === undefined) {
+      // normalizeBase32 already performs this check, but keep the decoder total.
+      throw new Error('Base32 value contains invalid characters')
+    }
+
+    accumulator = (accumulator << 5) | characterValue
+    availableBits += 5
+
+    if (availableBits >= 8) {
+      availableBits -= 8
+      decoded[outputIndex] = (accumulator >>> availableBits) & 0xff
+      outputIndex += 1
+      accumulator &= 2 ** availableBits - 1
+    }
+  }
+
+  return decoded
+}
+
+/** Parses a standard otpauth://totp URI without retaining the source URI. */
+export function parseOtpauthUri(value: string): OtpauthTotpConfig {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error('otpauth URI is required')
+  }
+
+  let uri: URL
+  try {
+    uri = new URL(value.trim())
+  } catch {
+    throw new Error('Invalid otpauth URI')
+  }
+
+  if (uri.protocol.toLowerCase() !== 'otpauth:') {
+    throw new Error('URI must use the otpauth scheme')
+  }
+  if (uri.hostname.toLowerCase() !== 'totp') {
+    throw new Error('Only otpauth TOTP URIs are supported')
+  }
+  if (uri.username || uri.password || uri.port || uri.hash) {
+    throw new Error('otpauth URI contains unsupported authority or fragment data')
+  }
+
+  rejectDuplicateParameters(uri.searchParams, ['secret', 'issuer', 'algorithm', 'digits', 'period'])
+
+  const rawLabel = uri.pathname.replace(/^\/+/, '')
+  let label: string
+  try {
+    label = decodeURIComponent(rawLabel).trim()
+  } catch {
+    throw new Error('otpauth label is not valid percent-encoding')
+  }
+  if (!label) {
+    throw new Error('otpauth account name is required')
+  }
+
+  const separatorIndex = label.indexOf(':')
+  const labelIssuer = separatorIndex === -1 ? undefined : label.slice(0, separatorIndex).trim()
+  const accountName = (separatorIndex === -1 ? label : label.slice(separatorIndex + 1)).trim()
+  if (!accountName) {
+    throw new Error('otpauth account name is required')
+  }
+  if (separatorIndex !== -1 && !labelIssuer) {
+    throw new Error('otpauth label issuer cannot be empty')
+  }
+
+  const rawSecret = uri.searchParams.get('secret')
+  if (!rawSecret) {
+    throw new Error('otpauth secret is required')
+  }
+  const secret = normalizeBase32(rawSecret)
+
+  const queryIssuer = normalizeOptionalLabel(uri.searchParams.get('issuer'), 'issuer')
+  if (labelIssuer && queryIssuer && labelIssuer !== queryIssuer) {
+    throw new Error('otpauth label issuer must match the issuer query parameter')
+  }
+
+  const algorithm = normalizeAlgorithm(uri.searchParams.get('algorithm') ?? DEFAULT_ALGORITHM)
+  const digits = parsePositiveIntegerParameter(
+    uri.searchParams.get('digits'),
+    'digits',
+    DEFAULT_DIGITS
+  )
+  validateDigits(digits)
+  const period = parsePositiveIntegerParameter(
+    uri.searchParams.get('period'),
+    'period',
+    DEFAULT_PERIOD
+  )
+  validatePeriod(period)
+
+  return {
+    type: 'totp',
+    accountName,
+    issuer: queryIssuer ?? labelIssuer,
+    secret,
+    algorithm,
+    digits,
+    period,
+  }
+}
+
+/** Builds a deterministic otpauth://totp URI from validated inputs. */
+export function buildOtpauthUri(options: BuildOtpauthUriOptions): string {
+  if (!options || typeof options !== 'object') {
+    throw new TypeError('otpauth options are required')
+  }
+
+  const accountName = normalizeRequiredLabel(options.accountName, 'account name')
+  const issuer = normalizeOptionalLabel(options.issuer, 'issuer')
+  const secret = normalizeBase32(options.secret)
+  const algorithm = normalizeAlgorithm(options.algorithm ?? DEFAULT_ALGORITHM)
+  const digits = options.digits ?? DEFAULT_DIGITS
+  const period = options.period ?? DEFAULT_PERIOD
+  validateDigits(digits)
+  validatePeriod(period)
+
+  const encodedAccount = encodeURIComponent(accountName)
+  const label = issuer ? `${encodeURIComponent(issuer)}:${encodedAccount}` : encodedAccount
+  const query = [
+    `secret=${encodeURIComponent(secret)}`,
+    ...(issuer ? [`issuer=${encodeURIComponent(issuer)}`] : []),
+    `algorithm=${algorithm}`,
+    `digits=${digits}`,
+    `period=${period}`,
+  ].join('&')
+
+  return `otpauth://totp/${label}?${query}`
+}
+
+/** Generates a TOTP value using HMAC through the Web Crypto API. */
+export async function generateTotp(secret: TotpSecret, options: TotpOptions = {}): Promise<string> {
+  const secretBytes = resolveSecretBytes(secret)
+  const resolved = resolveTotpOptions(options)
+  const counter = Math.floor(resolved.timestampSeconds / resolved.period)
+  const counterBytes = encodeCounter(counter)
+  const cryptoApi = getCryptoApi()
+  const hashName = toWebCryptoHash(resolved.algorithm)
+
+  const key = await cryptoApi.subtle.importKey(
+    'raw',
+    secretBytes,
+    { name: 'HMAC', hash: hashName },
+    false,
+    ['sign']
+  )
+  const digest = new Uint8Array(await cryptoApi.subtle.sign('HMAC', key, counterBytes))
+  const offset = digest[digest.length - 1]! & 0x0f
+  const binaryCode =
+    ((digest[offset]! & 0x7f) << 24) |
+    ((digest[offset + 1]! & 0xff) << 16) |
+    ((digest[offset + 2]! & 0xff) << 8) |
+    (digest[offset + 3]! & 0xff)
+  const code = binaryCode % 10 ** resolved.digits
+
+  return code.toString().padStart(resolved.digits, '0')
+}
+
+/**
+ * Verifies a TOTP code across the configured drift window. Delta is measured
+ * in time steps: -1 is the prior period, +1 is the next period.
+ */
+export async function verifyTotp(
+  code: string,
+  secret: TotpSecret,
+  options: VerifyTotpOptions = {}
+): Promise<TotpVerificationResult> {
+  const resolved = resolveTotpOptions(options)
+  const driftWindow = resolveDriftWindow(options)
+  const normalizedCode = typeof code === 'string' ? code.trim() : ''
+
+  if (!new RegExp(`^\\d{${resolved.digits}}$`).test(normalizedCode)) {
+    return { valid: false, delta: null }
+  }
+
+  const deltas = buildDriftSearchOrder(driftWindow)
+  for (const delta of deltas) {
+    const candidate = await generateTotp(secret, {
+      timestamp: resolved.timestampSeconds + delta * resolved.period,
+      period: resolved.period,
+      digits: resolved.digits,
+      algorithm: resolved.algorithm,
+    })
+
+    if (constantTimeEqual(normalizedCode, candidate)) {
+      return { valid: true, delta }
+    }
+  }
+
+  return { valid: false, delta: null }
+}
+
+/** Generates a cryptographically random, unpadded Base32 secret. */
+export function generateBase32Secret(byteLength = DEFAULT_SECRET_BYTES): string {
+  if (!Number.isInteger(byteLength) || byteLength <= 0 || byteLength > 65_536) {
+    throw new RangeError('Secret byte length must be an integer between 1 and 65536')
+  }
+
+  const cryptoApi = getCryptoApi()
+  const bytes = new Uint8Array(byteLength)
+  cryptoApi.getRandomValues(bytes)
+  return encodeBase32(bytes)
+}
+
+function rejectDuplicateParameters(parameters: URLSearchParams, names: string[]): void {
+  for (const name of names) {
+    if (parameters.getAll(name).length > 1) {
+      throw new Error(`otpauth URI contains duplicate ${name} parameters`)
+    }
+  }
+}
+
+function normalizeRequiredLabel(value: string, fieldName: string): string {
+  if (typeof value !== 'string') {
+    throw new TypeError(`otpauth ${fieldName} must be a string`)
+  }
+
+  const normalized = value.trim()
+  if (!normalized) {
+    throw new Error(`otpauth ${fieldName} is required`)
+  }
+  rejectControlCharacters(normalized, fieldName)
+  return normalized
+}
+
+function normalizeOptionalLabel(
+  value: string | null | undefined,
+  fieldName: string
+): string | undefined {
+  if (value === null || value === undefined) return undefined
+  const normalized = normalizeRequiredLabel(value, fieldName)
+  return normalized
+}
+
+function rejectControlCharacters(value: string, fieldName: string): void {
+  if (/\p{Cc}/u.test(value)) {
+    throw new Error(`otpauth ${fieldName} cannot contain control characters`)
+  }
+}
+
+function parsePositiveIntegerParameter(
+  value: string | null,
+  name: string,
+  defaultValue: number
+): number {
+  if (value === null) return defaultValue
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`otpauth ${name} must be a positive integer`)
+  }
+
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`otpauth ${name} must be a positive integer`)
+  }
+  return parsed
+}
+
+function normalizeAlgorithm(value: string): TotpAlgorithm {
+  const normalized = value.toUpperCase().replace(/-/g, '')
+  if (normalized === 'SHA1' || normalized === 'SHA256' || normalized === 'SHA512') {
+    return normalized
+  }
+  throw new Error('TOTP algorithm must be SHA1, SHA256, or SHA512')
+}
+
+function validateDigits(digits: number): void {
+  if (!Number.isInteger(digits) || digits < 1 || digits > 10) {
+    throw new RangeError('TOTP digits must be an integer between 1 and 10')
+  }
+}
+
+function validatePeriod(period: number): void {
+  if (!Number.isSafeInteger(period) || period <= 0) {
+    throw new RangeError('TOTP period must be a positive integer number of seconds')
+  }
+}
+
+function resolveTotpOptions(options: TotpOptions): ResolvedTotpOptions {
+  const period = options.period ?? DEFAULT_PERIOD
+  const digits = options.digits ?? DEFAULT_DIGITS
+  const algorithm = normalizeAlgorithm(options.algorithm ?? DEFAULT_ALGORITHM)
+  validatePeriod(period)
+  validateDigits(digits)
+
+  return {
+    timestampSeconds: resolveTimestampSeconds(options.timestamp),
+    period,
+    digits,
+    algorithm,
+  }
+}
+
+function resolveTimestampSeconds(timestamp: number | Date | undefined): number {
+  if (timestamp instanceof Date) {
+    const milliseconds = timestamp.getTime()
+    if (!Number.isFinite(milliseconds) || milliseconds < 0) {
+      throw new RangeError('TOTP timestamp must be a valid non-negative date')
+    }
+    return milliseconds / 1000
+  }
+
+  const numericTimestamp = timestamp ?? Date.now()
+  if (!Number.isFinite(numericTimestamp) || numericTimestamp < 0) {
+    throw new RangeError('TOTP timestamp must be a finite non-negative number')
+  }
+
+  // RFC examples use Unix seconds, while browser callers commonly provide Date.now().
+  return numericTimestamp >= 100_000_000_000 ? numericTimestamp / 1000 : numericTimestamp
+}
+
+function resolveDriftWindow(options: VerifyTotpOptions): number {
+  if (
+    options.window !== undefined &&
+    options.driftWindow !== undefined &&
+    options.window !== options.driftWindow
+  ) {
+    throw new Error('TOTP window and driftWindow options must match when both are provided')
+  }
+
+  const driftWindow = options.driftWindow ?? options.window ?? 0
+  if (!Number.isInteger(driftWindow) || driftWindow < 0 || driftWindow > MAX_DRIFT_WINDOW) {
+    throw new RangeError(`TOTP drift window must be an integer between 0 and ${MAX_DRIFT_WINDOW}`)
+  }
+  return driftWindow
+}
+
+function resolveSecretBytes(secret: TotpSecret): Uint8Array<ArrayBuffer> {
+  const bytes = typeof secret === 'string' ? decodeBase32(secret) : secret
+  if (!(bytes instanceof Uint8Array)) {
+    throw new TypeError('TOTP secret must be a Base32 string or Uint8Array')
+  }
+  if (bytes.length === 0) {
+    throw new Error('TOTP secret is required')
+  }
+  // Copy caller-owned views so Web Crypto receives a concrete ArrayBuffer-backed
+  // source rather than a view that could be backed by SharedArrayBuffer.
+  return new Uint8Array(bytes)
+}
+
+function encodeCounter(counter: number): Uint8Array<ArrayBuffer> {
+  if (!Number.isSafeInteger(counter) || counter < 0) {
+    throw new RangeError('TOTP counter is outside the supported range')
+  }
+
+  let remaining = BigInt(counter)
+  const encoded = new Uint8Array(8)
+  for (let index = encoded.length - 1; index >= 0; index -= 1) {
+    encoded[index] = Number(remaining & 0xffn)
+    remaining >>= 8n
+  }
+  return encoded
+}
+
+function toWebCryptoHash(algorithm: TotpAlgorithm): 'SHA-1' | 'SHA-256' | 'SHA-512' {
+  switch (algorithm) {
+    case 'SHA1':
+      return 'SHA-1'
+    case 'SHA256':
+      return 'SHA-256'
+    case 'SHA512':
+      return 'SHA-512'
+  }
+}
+
+function getCryptoApi(): Crypto {
+  const cryptoApi = globalThis.crypto
+  if (!cryptoApi?.subtle || typeof cryptoApi.getRandomValues !== 'function') {
+    throw new Error('Web Crypto API is unavailable')
+  }
+  return cryptoApi
+}
+
+function buildDriftSearchOrder(window: number): number[] {
+  const deltas = [0]
+  for (let offset = 1; offset <= window; offset += 1) {
+    deltas.push(-offset, offset)
+  }
+  return deltas
+}
+
+function constantTimeEqual(left: string, right: string): boolean {
+  if (left.length !== right.length) return false
+
+  let difference = 0
+  for (let index = 0; index < left.length; index += 1) {
+    difference |= left.charCodeAt(index) ^ right.charCodeAt(index)
+  }
+  return difference === 0
+}

--- a/src/lib/state/app-state-context.tsx
+++ b/src/lib/state/app-state-context.tsx
@@ -125,11 +125,15 @@ export function AppStateProvider({ children }: AppStateProviderProps) {
   // Token history methods
   const addToken = useCallback(
     (token: string) => {
+      // Raw tokens can contain sensitive claims and credentials. Persist them only
+      // after the user explicitly enables token history in Settings.
+      if (settings.persistTokenHistory !== true) return
+
       setTokenHistory((currentHistory) =>
         addTokenToHistory(currentHistory, token, settings.maxHistoryItems)
       )
     },
-    [setTokenHistory, settings.maxHistoryItems]
+    [setTokenHistory, settings.maxHistoryItems, settings.persistTokenHistory]
   )
 
   const updateToken = useCallback(

--- a/src/lib/state/types.ts
+++ b/src/lib/state/types.ts
@@ -56,6 +56,7 @@ export interface EnvironmentProfileDraft {
 // User settings
 export interface UserSettings {
   maxHistoryItems: number
+  persistTokenHistory: boolean
   tokenDisplayFormat: 'decoded' | 'encoded'
   enableDetailedValidation: boolean
   defaultTab: string
@@ -76,6 +77,7 @@ export const initialAppState: AppState = {
   environmentProfiles: [],
   settings: {
     maxHistoryItems: 10,
+    persistTokenHistory: false,
     tokenDisplayFormat: 'decoded',
     enableDetailedValidation: true,
     defaultTab: 'payload',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,8 +3,8 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import './index.css'
 import './components/navigation/nested-submenu.css'
-import { ThemeProvider } from './components/theme'
-import { AppStateProvider } from './lib/state'
+import { ThemeProvider } from './components/theme/theme-provider'
+import { AppStateProvider } from './lib/state/app-state-context'
 import { Layout } from './components/layout'
 import { Toaster } from './components/ui/sonner'
 import { DiagnosticsListener } from './components/common/DiagnosticsListener'
@@ -14,7 +14,9 @@ import { PageLoading } from './components/common/PageLoading'
 const HomePage = lazy(() => import('./features/home'))
 const NotFoundPage = lazy(() => import('./features/not-found'))
 const TokenInspectorPage = lazy(() => import('./features/tokenInspector/pages'))
+const TokenComparisonPage = lazy(() => import('./features/token-comparison/pages'))
 const OidcExplorerPage = lazy(() => import('./features/oidcExplorer/pages'))
+const RedirectUriDebuggerPage = lazy(() => import('./features/redirect-uri/pages'))
 const OAuthPlaygroundPage = lazy(() => import('./features/oauthPlayground/pages'))
 const OAuthCallbackPage = lazy(() => import('./features/oauthPlayground/pages/callback'))
 const DemoAuthPage = lazy(() => import('./features/oauthPlayground/pages/demo-auth'))
@@ -30,6 +32,10 @@ const SamlMetadataValidatorPage = lazy(() => import('./features/saml/pages/metad
 const SpMetadataGeneratorPage = lazy(() => import('./features/saml/pages/sp-metadata'))
 const LdapSchemaExplorerPage = lazy(() => import('./features/ldap/pages/schema-explorer/index.tsx'))
 const LdifBuilderPage = lazy(() => import('./features/ldap/pages/ldif-builder/index.tsx'))
+const LdapFilterStudioPage = lazy(() => import('./features/ldap-filter/pages'))
+const ScimResourceValidatorPage = lazy(() => import('./features/scim/pages/resource-validator'))
+const ScimPatchBuilderPage = lazy(() => import('./features/scim/pages/patch-builder'))
+const TotpDebuggerPage = lazy(() => import('./features/totp/pages'))
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -44,7 +50,9 @@ createRoot(document.getElementById('root')!).render(
                 <Route path="/" element={<Layout />}>
                   <Route index element={<HomePage />} />
                   <Route path="token-inspector" element={<TokenInspectorPage />} />
+                  <Route path="token-comparison" element={<TokenComparisonPage />} />
                   <Route path="oidc-explorer" element={<OidcExplorerPage />} />
+                  <Route path="oauth/redirect-uri" element={<RedirectUriDebuggerPage />} />
                   <Route path="oauth-playground" element={<OAuthPlaygroundPage />} />
                   <Route
                     path="oauth-playground/auth-code-pkce"
@@ -62,6 +70,10 @@ createRoot(document.getElementById('root')!).render(
                   <Route path="saml/sp-metadata" element={<SpMetadataGeneratorPage />} />
                   <Route path="ldap/schema-explorer" element={<LdapSchemaExplorerPage />} />
                   <Route path="ldap/ldif-builder" element={<LdifBuilderPage />} />
+                  <Route path="ldap/filter-studio" element={<LdapFilterStudioPage />} />
+                  <Route path="scim/resource-validator" element={<ScimResourceValidatorPage />} />
+                  <Route path="scim/patch-builder" element={<ScimPatchBuilderPage />} />
+                  <Route path="mfa/totp" element={<TotpDebuggerPage />} />
                   {/* Catch-all 404 route */}
                   <Route path="*" element={<NotFoundPage />} />
                 </Route>

--- a/src/tests/components/page-header.test.tsx
+++ b/src/tests/components/page-header.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { describe, expect, test } from 'bun:test'
+import { render } from '@testing-library/react'
+import { KeyRound } from 'lucide-react'
+import { PageHeader } from '@/components/page'
+
+describe('PageHeader', () => {
+  test('exposes the page title as a level-one heading', () => {
+    const view = render(
+      <PageHeader title="Token Claims Diff" description="Compare token claims." icon={KeyRound} />
+    )
+
+    expect(view.getByRole('heading', { level: 1, name: 'Token Claims Diff' })).toBeTruthy()
+    expect(view.getByText('Compare token claims.')).toBeTruthy()
+  })
+})

--- a/src/tests/features/demo-redirect.test.ts
+++ b/src/tests/features/demo-redirect.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  DEMO_CALLBACK_PATH,
+  isAllowedDemoRedirectUri,
+} from '@/features/oauthPlayground/utils/demo-redirect'
+
+describe('demo OAuth redirect validation', () => {
+  test('allows only the app callback by default', () => {
+    expect(
+      isAllowedDemoRedirectUri(
+        `https://iam.tools${DEMO_CALLBACK_PATH}`,
+        'https://iam.tools/api/auth'
+      )
+    ).toBe(true)
+    expect(
+      isAllowedDemoRedirectUri('https://evil.example/callback', 'https://iam.tools/api/auth')
+    ).toBe(false)
+    expect(
+      isAllowedDemoRedirectUri(
+        `https://iam.tools${DEMO_CALLBACK_PATH}?next=evil`,
+        'https://iam.tools/api/auth'
+      )
+    ).toBe(false)
+  })
+
+  test('allows local app callbacks across development ports', () => {
+    expect(
+      isAllowedDemoRedirectUri(
+        `http://127.0.0.1:5173${DEMO_CALLBACK_PATH}`,
+        'http://localhost:8788/api/auth'
+      )
+    ).toBe(true)
+  })
+
+  test('supports explicit exact registrations without allowing unsafe URI shapes', () => {
+    const registered = 'https://client.example.com/oauth/callback'
+    expect(isAllowedDemoRedirectUri(registered, 'https://iam.tools/api/auth', [registered])).toBe(
+      true
+    )
+    expect(
+      isAllowedDemoRedirectUri(`${registered}?extra=true`, 'https://iam.tools/api/auth', [
+        registered,
+      ])
+    ).toBe(false)
+    expect(
+      isAllowedDemoRedirectUri('javascript:alert(1)', 'https://iam.tools/api/auth', [
+        'javascript:alert(1)',
+      ])
+    ).toBe(false)
+  })
+})

--- a/src/tests/features/ldap-filter.test.ts
+++ b/src/tests/features/ldap-filter.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  encodeLdapFilterForUrl,
+  escapeLdapFilterValue,
+  explainLdapFilter,
+  formatLdapFilter,
+  parseLdapFilter,
+  unescapeLdapFilterValue,
+  validateLdapFilter,
+  type LdapFilterAst,
+} from '@/features/ldap-filter/utils'
+
+describe('LDAP RFC 4515 filter utilities', () => {
+  it('parses, formats, and explains nested boolean filters', () => {
+    const input =
+      '(&(|(objectClass=person)(objectClass=user))(!(accountStatus=disabled))(uid=jdoe))'
+    const ast = parseLdapFilter(input)
+
+    expect(ast.type).toBe('and')
+    if (ast.type !== 'and') throw new Error('Expected an AND filter')
+    expect(ast.children).toHaveLength(3)
+    expect(ast.children[0].type).toBe('or')
+    expect(ast.children[1].type).toBe('not')
+    expect(formatLdapFilter(ast)).toBe(input)
+
+    const pretty = formatLdapFilter(ast, true)
+    expect(pretty).toContain('\n')
+    expect(parseLdapFilter(pretty)).toEqual(ast)
+
+    const explanation = explainLdapFilter(ast)
+    expect(explanation).toContain('All of the following must match')
+    expect(explanation).toContain('Any of the following may match')
+    expect(explanation).toContain('The following must not match')
+    expect(explanation).toContain('uid equals "jdoe"')
+  })
+
+  it('distinguishes presence, substring wildcards, and escaped literal asterisks', () => {
+    expect(parseLdapFilter('(mail=*)')).toEqual({ type: 'presence', attribute: 'mail' })
+
+    expect(parseLdapFilter('(cn=Jo*n*Doe)')).toEqual({
+      type: 'substring',
+      attribute: 'cn',
+      initial: 'Jo',
+      any: ['n'],
+      final: 'Doe',
+    })
+
+    expect(parseLdapFilter('(cn=literal\\2astar)')).toEqual({
+      type: 'equality',
+      attribute: 'cn',
+      value: 'literal*star',
+    })
+
+    const repeatedWildcard = parseLdapFilter('(cn=**)')
+    expect(repeatedWildcard).toEqual({
+      type: 'substring',
+      attribute: 'cn',
+      initial: undefined,
+      any: [''],
+      final: undefined,
+    })
+    expect(formatLdapFilter(repeatedWildcard)).toBe('(cn=**)')
+  })
+
+  it('escapes assertion values so user input cannot inject another filter', () => {
+    const unsafe = 'alice*)(|(uid=*))'
+    const escaped = escapeLdapFilterValue(unsafe)
+
+    expect(escaped).toBe('alice\\2a\\29\\28|\\28uid=\\2a\\29\\29')
+    expect(unescapeLdapFilterValue(escaped)).toBe(unsafe)
+
+    const ast: LdapFilterAst = { type: 'equality', attribute: 'uid', value: unsafe }
+    const formatted = formatLdapFilter(ast)
+    expect(formatted).toBe('(uid=alice\\2a\\29\\28|\\28uid=\\2a\\29\\29)')
+    expect(parseLdapFilter(formatted)).toEqual(ast)
+  })
+
+  it('decodes escaped UTF-8 octets without corrupting multi-byte characters', () => {
+    expect(unescapeLdapFilterValue('Jos\\c3\\a9')).toBe('José')
+    expect(unescapeLdapFilterValue('Price: \\e2\\82\\ac10')).toBe('Price: €10')
+
+    const ast = parseLdapFilter('(cn=Jos\\c3\\a9)')
+    expect(ast).toEqual({ type: 'equality', attribute: 'cn', value: 'José' })
+    expect(formatLdapFilter(ast)).toBe('(cn=José)')
+  })
+
+  it('parses ordering and approximate comparison filters', () => {
+    expect(parseLdapFilter('(uidNumber>=1000)')).toEqual({
+      type: 'greaterOrEqual',
+      attribute: 'uidNumber',
+      value: '1000',
+    })
+    expect(parseLdapFilter('(pwdChangedTime<=20260713000000Z)')).toEqual({
+      type: 'lessOrEqual',
+      attribute: 'pwdChangedTime',
+      value: '20260713000000Z',
+    })
+    expect(parseLdapFilter('(cn~=John Doe)')).toEqual({
+      type: 'approx',
+      attribute: 'cn',
+      value: 'John Doe',
+    })
+  })
+
+  it('strictly URL-encodes a canonical filter', () => {
+    expect(encodeLdapFilterForUrl('(cn=John Doe)')).toBe('%28cn%3DJohn%20Doe%29')
+    expect(encodeLdapFilterForUrl(parseLdapFilter('(mail=*)'))).toBe('%28mail%3D%2A%29')
+  })
+
+  it('rejects malformed filters and reports useful source positions', () => {
+    const invalidFilters = [
+      '(&(cn=Alice)(sn=Smith)',
+      '(&)',
+      '(!(cn=Alice)(sn=Smith))',
+      '(cn=bad\\2)',
+      '(cn=bad\\zz)',
+      '(uidNumber>=1*2)',
+      '(cn:caseExactMatch:=Alice)',
+    ]
+
+    for (const filter of invalidFilters) {
+      const result = validateLdapFilter(filter)
+      expect(result.valid).toBe(false)
+      expect(result.ast).toBeNull()
+      expect(result.diagnostics).toHaveLength(1)
+      expect(result.diagnostics[0].message.length).toBeGreaterThan(8)
+      expect(result.diagnostics[0].position).toBeGreaterThanOrEqual(0)
+      expect(result.diagnostics[0].line).toBeGreaterThanOrEqual(1)
+      expect(result.diagnostics[0].column).toBeGreaterThanOrEqual(1)
+    }
+
+    const trailing = validateLdapFilter('(cn=Alice) trailing')
+    expect(trailing.valid).toBe(false)
+    expect(trailing.diagnostics[0]).toMatchObject({
+      position: 11,
+      line: 1,
+      column: 12,
+    })
+    expect(trailing.diagnostics[0].message).toContain('trailing input')
+  })
+
+  it('rejects malformed and incomplete escaped UTF-8 sequences', () => {
+    expect(() => unescapeLdapFilterValue('bad\\c3')).toThrow('Incomplete UTF-8')
+    expect(() => unescapeLdapFilterValue('bad\\a9')).toThrow('Invalid UTF-8')
+    expect(() => parseLdapFilter('(cn=bad\\c3)')).toThrow('Incomplete UTF-8')
+  })
+
+  it('returns the parsed AST from successful validation', () => {
+    const result = validateLdapFilter('  (cn=Alice)  ')
+    expect(result.valid).toBe(true)
+    expect(result.diagnostics).toEqual([])
+    expect(result.ast).toEqual({ type: 'equality', attribute: 'cn', value: 'Alice' })
+  })
+})

--- a/src/tests/features/redirect-uri.test.ts
+++ b/src/tests/features/redirect-uri.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  analyzeRedirectUri,
+  parseRegisteredRedirects,
+} from '@/features/redirect-uri/utils/redirect-uri'
+
+describe('OAuth redirect URI analysis', () => {
+  it('deduplicates and trims registered redirect lines', () => {
+    expect(
+      parseRegisteredRedirects(
+        ' https://a.example/cb \n\nhttps://a.example/cb\nhttps://b.example/cb '
+      )
+    ).toEqual(['https://a.example/cb', 'https://b.example/cb'])
+  })
+
+  it('accepts an exact HTTPS registration match', () => {
+    const result = analyzeRedirectUri(
+      'https://app.example/callback?tenant=acme',
+      'https://app.example/callback?tenant=acme'
+    )
+
+    expect(result.matchType).toBe('exact')
+    expect(result.safeToSend).toBe(true)
+    expect(result.findings.map((item) => item.code)).toContain('exact-match')
+    expect(result.findings.map((item) => item.code)).toContain('query-retention')
+  })
+
+  it('rejects fragments and normalized-only web matches', () => {
+    const fragment = analyzeRedirectUri(
+      'https://app.example/callback#result',
+      'https://app.example/callback#result'
+    )
+    expect(fragment.safeToSend).toBe(false)
+    expect(fragment.findings.map((item) => item.code)).toContain('fragment-prohibited')
+
+    const normalized = analyzeRedirectUri(
+      'https://APP.example/callback',
+      'https://app.example/callback'
+    )
+    expect(normalized.matchType).toBe('normalized-only')
+    expect(normalized.findings.map((item) => item.code)).toContain('not-exact')
+  })
+
+  it('supports the native loopback dynamic-port exception', () => {
+    const result = analyzeRedirectUri(
+      'http://127.0.0.1:51004/oauth/callback',
+      'http://127.0.0.1:49152/oauth/callback'
+    )
+
+    expect(result.matchType).toBe('loopback-port')
+    expect(result.safeToSend).toBe(true)
+    expect(result.findings.map((item) => item.code)).toContain('loopback-port-match')
+  })
+
+  it('blocks insecure, wildcard, and dangerous redirect patterns', () => {
+    const insecure = analyzeRedirectUri('http://app.example/callback', 'https://*.example/callback')
+    expect(insecure.safeToSend).toBe(false)
+    expect(insecure.findings.map((item) => item.code)).toContain('insecure-http')
+    expect(insecure.findings.map((item) => item.code)).toContain('wildcard-registration')
+
+    const dangerous = analyzeRedirectUri('javascript:alert(1)', 'javascript:alert(1)')
+    expect(dangerous.safeToSend).toBe(false)
+    expect(dangerous.findings.map((item) => item.code)).toContain('dangerous-scheme')
+  })
+
+  it('blocks exact matches for unsupported registered and unknown schemes', () => {
+    for (const uri of [
+      'mailto:user@example.com',
+      'ftp://example.com/callback',
+      'myapp:/oauth/callback',
+      'my.app+oauth:/callback',
+    ]) {
+      const result = analyzeRedirectUri(uri, uri)
+
+      expect(result.matchType).toBe('exact')
+      expect(result.safeToSend).toBe(false)
+      expect(result.findings.map((item) => item.code)).toContain('unsupported-scheme')
+    }
+  })
+
+  it('allows an exact reverse-domain private-use scheme match', () => {
+    const uri = 'com.example.app:/oauth/callback'
+    const result = analyzeRedirectUri(uri, uri)
+
+    expect(result.matchType).toBe('exact')
+    expect(result.safeToSend).toBe(true)
+    expect(result.findings.map((item) => item.code)).toContain('custom-scheme')
+  })
+
+  it('does not claim allowlist safety without registrations', () => {
+    const result = analyzeRedirectUri('https://app.example/callback', '')
+    expect(result.safeToSend).toBe(false)
+    expect(result.findings.map((item) => item.code)).toContain('no-registrations')
+  })
+})

--- a/src/tests/features/scim-patch.test.ts
+++ b/src/tests/features/scim-patch.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  SCIM_PATCH_OP_SCHEMA,
+  buildScimPatch,
+  isValidScimPath,
+  validateScimPatch,
+} from '@/features/scim/utils'
+
+function diagnosticCodes(input: string): string[] {
+  return validateScimPatch(input).diagnostics.map((diagnostic) => diagnostic.code)
+}
+
+describe('SCIM PATCH utilities', () => {
+  it('exports the PatchOp schema URN', () => {
+    expect(SCIM_PATCH_OP_SCHEMA).toBe('urn:ietf:params:scim:api:messages:2.0:PatchOp')
+  })
+
+  it('accepts add, remove, and replace operations', () => {
+    const result = validateScimPatch(
+      JSON.stringify({
+        schemas: [SCIM_PATCH_OP_SCHEMA],
+        Operations: [
+          { op: 'add', path: 'members', value: [{ value: 'user-123' }] },
+          { op: 'replace', path: 'name.givenName', value: 'Barbara' },
+          { op: 'remove', path: 'emails[type eq "work"].value' },
+        ],
+      })
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.operations).toEqual([
+      { op: 'add', path: 'members', value: [{ value: 'user-123' }] },
+      { op: 'replace', path: 'name.givenName', value: 'Barbara' },
+      { op: 'remove', path: 'emails[type eq "work"].value' },
+    ])
+  })
+
+  it('supports schema-qualified and filtered paths', () => {
+    expect(isValidScimPath('userName')).toBe(true)
+    expect(isValidScimPath('name.givenName')).toBe(true)
+    expect(isValidScimPath('members[value eq "user-123"]')).toBe(true)
+    expect(
+      isValidScimPath('urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.value')
+    ).toBe(true)
+    expect(isValidScimPath('emails[type eq "work"].value')).toBe(true)
+    expect(isValidScimPath('emails[]')).toBe(false)
+    expect(isValidScimPath('emails[type maybe "work"]')).toBe(false)
+    expect(isValidScimPath('name..givenName')).toBe(false)
+  })
+
+  it('rejects invalid documents, schemas, and empty operation lists', () => {
+    expect(diagnosticCodes('{bad-json')).toContain('invalid_json')
+    expect(diagnosticCodes('[]')).toContain('patch_type')
+    expect(
+      diagnosticCodes(
+        JSON.stringify({ schemas: [], Operations: [{ op: 'remove', path: 'title' }] })
+      )
+    ).toContain('patch_schema_missing')
+    expect(
+      diagnosticCodes(JSON.stringify({ schemas: [SCIM_PATCH_OP_SCHEMA], Operations: [] }))
+    ).toContain('operations_empty')
+  })
+
+  it('validates operation names and required path/value fields', () => {
+    const result = validateScimPatch(
+      JSON.stringify({
+        schemas: [SCIM_PATCH_OP_SCHEMA],
+        Operations: [
+          { op: 'delete', path: 'title' },
+          { op: 'remove' },
+          { op: 'add', path: 'emails' },
+          { op: 'replace', path: 'name..givenName', value: 'Barbara' },
+        ],
+      })
+    )
+
+    const codes = result.diagnostics.map((diagnostic) => diagnostic.code)
+    expect(result.valid).toBe(false)
+    expect(codes).toContain('operation_name_invalid')
+    expect(codes).toContain('remove_path_required')
+    expect(codes).toContain('operation_value_required')
+    expect(codes).toContain('operation_path_syntax')
+  })
+
+  it('normalizes operation case with a warning', () => {
+    const result = validateScimPatch(
+      JSON.stringify({
+        schemas: [SCIM_PATCH_OP_SCHEMA],
+        Operations: [{ op: 'Replace', path: 'active', value: true }],
+      })
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.operations[0]?.op).toBe('replace')
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ severity: 'warning', code: 'operation_name_case' })
+    )
+  })
+
+  it('omits ignored values from normalized remove operations', () => {
+    const result = validateScimPatch(
+      JSON.stringify({
+        schemas: [SCIM_PATCH_OP_SCHEMA],
+        Operations: [{ op: 'remove', path: 'nickName', value: 'ignored' }],
+      })
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.operations).toEqual([{ op: 'remove', path: 'nickName' }])
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ severity: 'warning', code: 'remove_value_ignored' })
+    )
+  })
+
+  it('builds a canonical document and formatted JSON', () => {
+    const result = buildScimPatch([
+      { op: 'replace', path: ' active ', value: false },
+      { op: 'add', value: { title: 'Tour Guide' } },
+      { op: 'remove', path: 'nickName' },
+    ])
+
+    expect(result.document).toEqual({
+      schemas: [SCIM_PATCH_OP_SCHEMA],
+      Operations: [
+        { op: 'replace', path: 'active', value: false },
+        { op: 'add', value: { title: 'Tour Guide' } },
+        { op: 'remove', path: 'nickName' },
+      ],
+    })
+    expect(JSON.parse(result.json)).toEqual(result.document)
+    expect(result.json).toContain('\n  "Operations"')
+  })
+
+  it('refuses to build empty or invalid operation sets', () => {
+    expect(() => buildScimPatch([])).toThrow('At least one')
+    expect(() => buildScimPatch([{ op: 'remove', path: 'emails[]' }])).toThrow('invalid SCIM path')
+    expect(() =>
+      buildScimPatch([{ op: 'replace', path: 'displayName', value: undefined }])
+    ).toThrow('requires a value')
+  })
+})

--- a/src/tests/features/scim-resource-validation.test.ts
+++ b/src/tests/features/scim-resource-validation.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  SCIM_ENTERPRISE_USER_SCHEMA,
+  SCIM_GROUP_SCHEMA,
+  SCIM_USER_SCHEMA,
+  validateScimResource,
+} from '@/features/scim/utils'
+
+function diagnosticCodes(input: string): string[] {
+  return validateScimResource(input).diagnostics.map((diagnostic) => diagnostic.code)
+}
+
+describe('SCIM resource validation', () => {
+  it('exports the standard resource schema URNs', () => {
+    expect(SCIM_USER_SCHEMA).toBe('urn:ietf:params:scim:schemas:core:2.0:User')
+    expect(SCIM_GROUP_SCHEMA).toBe('urn:ietf:params:scim:schemas:core:2.0:Group')
+    expect(SCIM_ENTERPRISE_USER_SCHEMA).toBe(
+      'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User'
+    )
+  })
+
+  it('accepts a User with common attributes and the Enterprise extension', () => {
+    const resource = {
+      schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+      id: '2819c223-7f76-453a-919d-413861904646',
+      userName: 'bjensen@example.com',
+      active: true,
+      name: { givenName: 'Barbara', familyName: 'Jensen' },
+      emails: [
+        { value: 'bjensen@example.com', type: 'work', primary: true },
+        { value: 'babs@example.org', type: 'home' },
+      ],
+      [SCIM_ENTERPRISE_USER_SCHEMA]: {
+        employeeNumber: '701984',
+        department: 'Tour Operations',
+        manager: { value: '26118915-6090-4610-87e4-49d8ca9f808d' },
+      },
+    }
+
+    const result = validateScimResource(JSON.stringify(resource))
+
+    expect(result.valid).toBe(true)
+    expect(result.resourceType).toBe('User')
+    expect(result.parsed?.userName).toBe('bjensen@example.com')
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ severity: 'info', code: 'resource_type_detected' })
+    )
+  })
+
+  it('accepts a Group with members', () => {
+    const result = validateScimResource(
+      JSON.stringify({
+        schemas: [SCIM_GROUP_SCHEMA],
+        displayName: 'Tour Guides',
+        members: [
+          {
+            value: '2819c223-7f76-453a-919d-413861904646',
+            display: 'Babs Jensen',
+          },
+        ],
+      })
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.resourceType).toBe('Group')
+  })
+
+  it('rejects invalid JSON and non-object JSON', () => {
+    expect(diagnosticCodes('{not-json')).toContain('invalid_json')
+    expect(diagnosticCodes('[]')).toContain('resource_type')
+    expect(diagnosticCodes('null')).toContain('resource_type')
+  })
+
+  it('requires schemas and the resource-specific display attribute', () => {
+    const missingSchemas = validateScimResource(JSON.stringify({ userName: 'bjensen' }))
+    expect(missingSchemas.valid).toBe(false)
+    expect(missingSchemas.resourceType).toBe('Unknown')
+    expect(missingSchemas.diagnostics.map((item) => item.code)).toContain('schemas_missing')
+
+    expect(diagnosticCodes(JSON.stringify({ schemas: [SCIM_USER_SCHEMA] }))).toContain(
+      'required_attribute_missing'
+    )
+    expect(diagnosticCodes(JSON.stringify({ schemas: [SCIM_GROUP_SCHEMA] }))).toContain(
+      'required_attribute_missing'
+    )
+  })
+
+  it('checks common, complex, and multi-valued attribute types', () => {
+    const result = validateScimResource(
+      JSON.stringify({
+        schemas: [SCIM_USER_SCHEMA],
+        userName: 'bjensen',
+        active: 'yes',
+        name: 'Barbara Jensen',
+        emails: ['bjensen@example.com', { value: 123, primary: 'true' }],
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ path: '$.active', code: 'attribute_type' })
+    )
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ path: '$.name', code: 'complex_attribute_type' })
+    )
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ path: '$.emails[0]', code: 'multi_valued_item_type' })
+    )
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ path: '$.emails[1].primary', code: 'primary_type' })
+    )
+  })
+
+  it('allows at most one primary value per multi-valued attribute', () => {
+    const result = validateScimResource(
+      JSON.stringify({
+        schemas: [SCIM_USER_SCHEMA],
+        userName: 'bjensen',
+        emails: [
+          { value: 'one@example.com', primary: true },
+          { value: 'two@example.com', primary: true },
+        ],
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ path: '$.emails', code: 'multiple_primary_values' })
+    )
+  })
+
+  it('enforces extension/schema consistency in both directions', () => {
+    const missingObject = validateScimResource(
+      JSON.stringify({
+        schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+        userName: 'bjensen',
+      })
+    )
+    expect(missingObject.diagnostics.map((item) => item.code)).toContain('extension_value_missing')
+
+    const missingSchema = validateScimResource(
+      JSON.stringify({
+        schemas: [SCIM_USER_SCHEMA],
+        userName: 'bjensen',
+        [SCIM_ENTERPRISE_USER_SCHEMA]: { department: 'Operations' },
+      })
+    )
+    expect(missingSchema.diagnostics.map((item) => item.code)).toContain('extension_schema_missing')
+
+    const wrongResource = validateScimResource(
+      JSON.stringify({
+        schemas: [SCIM_GROUP_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+        displayName: 'Operations',
+        [SCIM_ENTERPRISE_USER_SCHEMA]: { department: 'Operations' },
+      })
+    )
+    expect(wrongResource.diagnostics.map((item) => item.code)).toContain('extension_resource_type')
+  })
+
+  it('requires a top-level extension object for every declared non-core schema URI', () => {
+    const customSchema = 'urn:example:scim:schemas:custom:2.0:User'
+    const missingObject = validateScimResource(
+      JSON.stringify({
+        schemas: [SCIM_USER_SCHEMA, customSchema],
+        userName: 'bjensen',
+      })
+    )
+
+    expect(missingObject.valid).toBe(false)
+    expect(missingObject.diagnostics).toContainEqual(
+      expect.objectContaining({
+        path: `$[${JSON.stringify(customSchema)}]`,
+        code: 'extension_value_missing',
+      })
+    )
+
+    const matchingObject = validateScimResource(
+      JSON.stringify({
+        schemas: [SCIM_USER_SCHEMA, customSchema],
+        userName: 'bjensen',
+        [customSchema]: { accountTier: 'standard' },
+      })
+    )
+
+    expect(matchingObject.valid).toBe(true)
+    expect(matchingObject.diagnostics.map((item) => item.code)).not.toContain(
+      'extension_value_missing'
+    )
+  })
+
+  it('warns when meta.resourceType disagrees with schemas', () => {
+    const result = validateScimResource(
+      JSON.stringify({
+        schemas: [SCIM_USER_SCHEMA],
+        userName: 'bjensen',
+        meta: { resourceType: 'Group' },
+      })
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ severity: 'warning', code: 'meta_resource_type_mismatch' })
+    )
+  })
+})

--- a/src/tests/features/token-comparison.test.ts
+++ b/src/tests/features/token-comparison.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  compareTokens,
+  createExampleComparisonTokens,
+  decodeTokenForComparison,
+} from '@/features/token-comparison/utils/token-comparison'
+
+function encode(value: unknown): string {
+  const bytes = new TextEncoder().encode(JSON.stringify(value))
+  let binary = ''
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+}
+
+function token(payload: unknown, header: unknown = { alg: 'RS256' }) {
+  return `${encode(header)}.${encode(payload)}.signature`
+}
+
+describe('token claims comparison', () => {
+  it('rejects empty and malformed compact tokens', () => {
+    expect(decodeTokenForComparison('').ok).toBe(false)
+    expect(decodeTokenForComparison('not-a-jwt').ok).toBe(false)
+  })
+
+  it('rejects decoded headers and payloads that are not JSON objects', () => {
+    for (const invalidValue of [null, true, 42, 'claims', []]) {
+      const invalidHeader = decodeTokenForComparison(token({}, invalidValue))
+      const invalidPayload = decodeTokenForComparison(token(invalidValue))
+
+      expect(invalidHeader).toEqual({
+        ok: false,
+        error: 'The JWT header must be a JSON object.',
+      })
+      expect(invalidPayload).toEqual({
+        ok: false,
+        error: 'The JWT payload must be a JSON object.',
+      })
+    }
+
+    expect(() => compareTokens(token(null), token({}))).toThrow(
+      'Both values must be decodable compact JWTs before they can be compared.'
+    )
+  })
+
+  it('compares nested, added, removed, and changed claims', () => {
+    const result = compareTokens(
+      token({ sub: 'user-1', profile: { department: 'Support', region: 'us' }, legacy: true }),
+      token({ sub: 'user-1', profile: { department: 'Finance', region: 'us' }, active: true })
+    )
+
+    expect(result.differences).toContainEqual(
+      expect.objectContaining({ section: 'payload', path: 'profile.department', kind: 'changed' })
+    )
+    expect(result.differences).toContainEqual(
+      expect.objectContaining({ path: 'active', kind: 'added' })
+    )
+    expect(result.differences).toContainEqual(
+      expect.objectContaining({ path: 'legacy', kind: 'removed' })
+    )
+    expect(result.differences).toContainEqual(
+      expect.objectContaining({ path: 'profile.region', kind: 'unchanged' })
+    )
+  })
+
+  it('treats set-like claims as order-insensitive and reports member drift', () => {
+    const result = compareTokens(
+      token({ aud: ['orders', 'billing'], scope: 'openid profile', roles: ['reader'] }),
+      token({
+        aud: ['billing', 'orders'],
+        scope: 'profile openid email',
+        roles: ['reader', 'admin'],
+      })
+    )
+
+    expect(result.differences).toContainEqual(
+      expect.objectContaining({ path: 'aud', kind: 'unchanged' })
+    )
+    expect(result.differences).toContainEqual(
+      expect.objectContaining({ path: 'scope', addedValues: ['email'], removedValues: [] })
+    )
+    expect(result.differences).toContainEqual(
+      expect.objectContaining({ path: 'roles', addedValues: ['admin'], removedValues: [] })
+    )
+  })
+
+  it('summarizes identity and time deltas', () => {
+    const result = compareTokens(
+      token({ iss: 'https://id.example', sub: '123', aud: 'api', iat: 100, exp: 3700 }),
+      token({ iss: 'https://id.example', sub: '123', aud: 'api', iat: 220, exp: 2020 })
+    )
+
+    expect(result.metadata.issuedAtDeltaSeconds).toBe(120)
+    expect(result.metadata.expiresAtDeltaSeconds).toBe(-1680)
+    expect(result.metadata.lifetimeDeltaSeconds).toBe(-1800)
+    expect(result.metadata.left.audiences).toEqual(['api'])
+  })
+
+  it('creates a meaningful, decodable comparison example', () => {
+    const example = createExampleComparisonTokens(1_700_000_000)
+    const result = compareTokens(example.left, example.right)
+
+    expect(result.counts.changed).toBeGreaterThan(3)
+    expect(result.differences).toContainEqual(
+      expect.objectContaining({ path: 'authentication_method', kind: 'added' })
+    )
+  })
+})

--- a/src/tests/features/totp-debugger.test.tsx
+++ b/src/tests/features/totp-debugger.test.tsx
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import TotpDebuggerPage, { buildTotpVerificationKey } from '@/features/totp/pages'
+
+if (!globalThis.DocumentFragment && window.DocumentFragment) {
+  ;(
+    globalThis as typeof globalThis & { DocumentFragment: typeof DocumentFragment }
+  ).DocumentFragment = window.DocumentFragment
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('TOTP Debugger', () => {
+  it('renders nonstandard digits and period parsed from an otpauth URI', () => {
+    const view = render(<TotpDebuggerPage />)
+    const input = view.getByTestId('totp-secret-input')
+
+    fireEvent.change(input, {
+      target: {
+        value:
+          'otpauth://totp/Example:alice?secret=JBSWY3DPEHPK3PXP&issuer=Example&digits=7&period=45',
+      },
+    })
+
+    expect((view.getByTestId('totp-effective-digits') as HTMLInputElement).value).toBe('7 digits')
+    expect((view.getByTestId('totp-effective-period') as HTMLInputElement).value).toBe('45 seconds')
+    expect(view.container.textContent).toContain('Read from the otpauth URI.')
+  })
+
+  it('changes the verification identity when the displayed time step advances', () => {
+    const base = {
+      secret: 'JBSWY3DPEHPK3PXP',
+      algorithm: 'SHA1' as const,
+      digits: 6,
+      period: 30,
+      candidateCode: '123456',
+      driftWindow: 1,
+    }
+
+    const verifiedAtStep = buildTotpVerificationKey({ ...base, step: 100 })
+    const currentStep = buildTotpVerificationKey({ ...base, step: 101 })
+
+    expect(currentStep).not.toBe(verifiedAtStep)
+  })
+})

--- a/src/tests/features/totp-utils.test.ts
+++ b/src/tests/features/totp-utils.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  buildOtpauthUri,
+  decodeBase32,
+  encodeBase32,
+  generateBase32Secret,
+  generateTotp,
+  normalizeBase32,
+  parseOtpauthUri,
+  verifyTotp,
+  type TotpAlgorithm,
+} from '@/features/totp/utils'
+
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+describe('Base32 utilities', () => {
+  it('encodes and decodes the RFC 4648 foobar example', () => {
+    const encoded = encodeBase32(encoder.encode('foobar'))
+
+    expect(encoded).toBe('MZXW6YTBOI')
+    expect(decoder.decode(decodeBase32(encoded))).toBe('foobar')
+    expect(decoder.decode(decodeBase32('MZXW6YTBOI======'))).toBe('foobar')
+  })
+
+  it('normalizes lowercase, whitespace, and valid padding', () => {
+    expect(normalizeBase32(' mzxw6ytb oi======\n')).toBe('MZXW6YTBOI')
+  })
+
+  it('round-trips arbitrary byte values', () => {
+    const bytes = Uint8Array.from({ length: 256 }, (_, index) => index)
+    expect(decodeBase32(encodeBase32(bytes))).toEqual(bytes)
+  })
+
+  it.each([
+    ['', 'required'],
+    ['MZXW6Y!B', 'invalid characters'],
+    ['MZXW6YTB=', 'invalid padding'],
+    ['M=ZXW6YTB', 'padding'],
+    ['M', 'invalid length'],
+    ['MZ', 'trailing bits'],
+  ])('rejects malformed Base32 input %p', (input, message) => {
+    expect(() => normalizeBase32(input)).toThrow(message)
+    expect(() => decodeBase32(input)).toThrow(message)
+  })
+
+  it('rejects non-byte-array encode input at runtime', () => {
+    expect(() => encodeBase32('not bytes' as unknown as Uint8Array)).toThrow('Uint8Array')
+  })
+})
+
+describe('otpauth URI utilities', () => {
+  const secret = 'JBSWY3DPEHPK3PXP'
+
+  it('parses a complete, percent-encoded TOTP URI', () => {
+    const parsed = parseOtpauthUri(
+      'otpauth://totp/Example%20Co:alice%40example.com?secret=jbsw%20y3dp%20ehpk%203pxp&issuer=Example%20Co&algorithm=sha-256&digits=8&period=45'
+    )
+
+    expect(parsed).toEqual({
+      type: 'totp',
+      accountName: 'alice@example.com',
+      issuer: 'Example Co',
+      secret,
+      algorithm: 'SHA256',
+      digits: 8,
+      period: 45,
+    })
+  })
+
+  it('applies interoperable defaults when optional parameters are absent', () => {
+    expect(parseOtpauthUri(`otpauth://totp/alice?secret=${secret}`)).toEqual({
+      type: 'totp',
+      accountName: 'alice',
+      secret,
+      algorithm: 'SHA1',
+      digits: 6,
+      period: 30,
+    })
+  })
+
+  it('builds a deterministic URI that round-trips Unicode labels', () => {
+    const uri = buildOtpauthUri({
+      accountName: 'álïce@example.com',
+      issuer: 'Example & Co',
+      secret: secret.toLowerCase(),
+      algorithm: 'SHA512',
+      digits: 8,
+      period: 60,
+    })
+
+    expect(uri).toBe(
+      'otpauth://totp/Example%20%26%20Co:%C3%A1l%C3%AFce%40example.com?secret=JBSWY3DPEHPK3PXP&issuer=Example%20%26%20Co&algorithm=SHA512&digits=8&period=60'
+    )
+    expect(parseOtpauthUri(uri)).toEqual({
+      type: 'totp',
+      accountName: 'álïce@example.com',
+      issuer: 'Example & Co',
+      secret,
+      algorithm: 'SHA512',
+      digits: 8,
+      period: 60,
+    })
+  })
+
+  it.each([
+    ['https://totp/alice?secret=JBSWY3DPEHPK3PXP', 'otpauth scheme'],
+    ['otpauth://hotp/alice?secret=JBSWY3DPEHPK3PXP', 'Only otpauth TOTP'],
+    ['otpauth://totp/?secret=JBSWY3DPEHPK3PXP', 'account name'],
+    ['otpauth://totp/alice', 'secret is required'],
+    ['otpauth://totp/alice?secret=INVALID1', 'invalid characters'],
+    ['otpauth://totp/Issuer:alice?secret=JBSWY3DPEHPK3PXP&issuer=Other', 'must match'],
+    ['otpauth://totp/alice?secret=JBSWY3DPEHPK3PXP&secret=JBSWY3DPEHPK3PXP', 'duplicate secret'],
+    ['otpauth://totp/alice?secret=JBSWY3DPEHPK3PXP&algorithm=MD5', 'algorithm'],
+    ['otpauth://totp/alice?secret=JBSWY3DPEHPK3PXP&digits=0', 'positive integer'],
+    ['otpauth://totp/alice?secret=JBSWY3DPEHPK3PXP&period=abc', 'positive integer'],
+  ])('rejects malformed or unsupported URI %p', (uri, message) => {
+    expect(() => parseOtpauthUri(uri)).toThrow(message)
+  })
+
+  it('rejects invalid builder values', () => {
+    expect(() => buildOtpauthUri({ accountName: '', secret })).toThrow('account name')
+    expect(() => buildOtpauthUri({ accountName: 'alice', secret, digits: 11 })).toThrow('digits')
+    expect(() => buildOtpauthUri({ accountName: 'alice', secret, period: 0 })).toThrow('period')
+  })
+})
+
+describe('RFC 6238 TOTP', () => {
+  const secrets: Record<TotpAlgorithm, string> = {
+    SHA1: encodeBase32(encoder.encode('12345678901234567890')),
+    SHA256: encodeBase32(encoder.encode('12345678901234567890123456789012')),
+    SHA512: encodeBase32(
+      encoder.encode('1234567890123456789012345678901234567890123456789012345678901234')
+    ),
+  }
+
+  const vectors: Array<{
+    timestamp: number
+    expected: Record<TotpAlgorithm, string>
+  }> = [
+    {
+      timestamp: 59,
+      expected: { SHA1: '94287082', SHA256: '46119246', SHA512: '90693936' },
+    },
+    {
+      timestamp: 1_111_111_109,
+      expected: { SHA1: '07081804', SHA256: '68084774', SHA512: '25091201' },
+    },
+    {
+      timestamp: 1_111_111_111,
+      expected: { SHA1: '14050471', SHA256: '67062674', SHA512: '99943326' },
+    },
+    {
+      timestamp: 1_234_567_890,
+      expected: { SHA1: '89005924', SHA256: '91819424', SHA512: '93441116' },
+    },
+    {
+      timestamp: 2_000_000_000,
+      expected: { SHA1: '69279037', SHA256: '90698825', SHA512: '38618901' },
+    },
+    {
+      timestamp: 20_000_000_000,
+      expected: { SHA1: '65353130', SHA256: '77737706', SHA512: '47863826' },
+    },
+  ]
+
+  for (const vector of vectors) {
+    for (const algorithm of ['SHA1', 'SHA256', 'SHA512'] as const) {
+      it(`matches Appendix B ${algorithm} at Unix time ${vector.timestamp}`, async () => {
+        const code = await generateTotp(secrets[algorithm], {
+          timestamp: vector.timestamp,
+          period: 30,
+          digits: 8,
+          algorithm,
+        })
+
+        expect(code).toBe(vector.expected[algorithm])
+      })
+    }
+  }
+
+  it('accepts Date and JavaScript millisecond timestamps', async () => {
+    const secondsCode = await generateTotp(secrets.SHA1, {
+      timestamp: 1_234_567_890,
+      digits: 8,
+    })
+    const millisecondsCode = await generateTotp(secrets.SHA1, {
+      timestamp: 1_234_567_890_000,
+      digits: 8,
+    })
+    const dateCode = await generateTotp(secrets.SHA1, {
+      timestamp: new Date(1_234_567_890_000),
+      digits: 8,
+    })
+
+    expect(millisecondsCode).toBe(secondsCode)
+    expect(dateCode).toBe(secondsCode)
+  })
+
+  it('supports custom period and digit counts', async () => {
+    const sixDigits = await generateTotp(secrets.SHA1, {
+      timestamp: 59,
+      period: 60,
+      digits: 6,
+    })
+
+    expect(sixDigits).toMatch(/^\d{6}$/)
+  })
+
+  it('rejects invalid options and secrets', async () => {
+    await expect(generateTotp('', { timestamp: 59 })).rejects.toThrow('required')
+    await expect(generateTotp(secrets.SHA1, { timestamp: -1 })).rejects.toThrow('timestamp')
+    await expect(generateTotp(secrets.SHA1, { period: 0 })).rejects.toThrow('period')
+    await expect(generateTotp(secrets.SHA1, { digits: 11 })).rejects.toThrow('digits')
+    await expect(
+      generateTotp(secrets.SHA1, { algorithm: 'MD5' as unknown as TotpAlgorithm })
+    ).rejects.toThrow('algorithm')
+  })
+})
+
+describe('TOTP verification', () => {
+  const secret = encodeBase32(encoder.encode('12345678901234567890'))
+
+  it('returns delta zero for the current time step', async () => {
+    await expect(
+      verifyTotp('94287082', secret, {
+        timestamp: 59,
+        digits: 8,
+        algorithm: 'SHA1',
+      })
+    ).resolves.toEqual({ valid: true, delta: 0 })
+  })
+
+  it('finds previous and future codes within the configured drift window', async () => {
+    const priorCode = await generateTotp(secret, { timestamp: 29, digits: 8 })
+    const futureCode = await generateTotp(secret, { timestamp: 89, digits: 8 })
+
+    await expect(
+      verifyTotp(priorCode, secret, { timestamp: 59, digits: 8, window: 1 })
+    ).resolves.toEqual({ valid: true, delta: -1 })
+    await expect(
+      verifyTotp(futureCode, secret, { timestamp: 59, digits: 8, driftWindow: 1 })
+    ).resolves.toEqual({ valid: true, delta: 1 })
+  })
+
+  it('rejects codes outside the window or with the wrong shape', async () => {
+    const futureCode = await generateTotp(secret, { timestamp: 89, digits: 8 })
+
+    await expect(
+      verifyTotp(futureCode, secret, { timestamp: 59, digits: 8, window: 0 })
+    ).resolves.toEqual({ valid: false, delta: null })
+    await expect(
+      verifyTotp('not-a-code', secret, { timestamp: 59, digits: 8, window: 1 })
+    ).resolves.toEqual({ valid: false, delta: null })
+  })
+
+  it('validates drift-window options', async () => {
+    await expect(
+      verifyTotp('94287082', secret, { timestamp: 59, digits: 8, window: -1 })
+    ).rejects.toThrow('drift window')
+    await expect(
+      verifyTotp('94287082', secret, {
+        timestamp: 59,
+        digits: 8,
+        window: 1,
+        driftWindow: 2,
+      })
+    ).rejects.toThrow('must match')
+  })
+})
+
+describe('random Base32 secret generation', () => {
+  it('uses the requested entropy length and produces valid Base32', () => {
+    const secret = generateBase32Secret(20)
+
+    expect(secret).toMatch(/^[A-Z2-7]+$/)
+    expect(secret).toHaveLength(32)
+    expect(decodeBase32(secret)).toHaveLength(20)
+  })
+
+  it('produces distinct values', () => {
+    expect(generateBase32Secret()).not.toBe(generateBase32Secret())
+  })
+
+  it('rejects invalid entropy lengths', () => {
+    expect(() => generateBase32Secret(0)).toThrow('byte length')
+    expect(() => generateBase32Secret(65_537)).toThrow('byte length')
+  })
+})

--- a/src/tests/lib/token-history-state.test.tsx
+++ b/src/tests/lib/token-history-state.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react'
+import { AppStateProvider, useSettings, useTokenHistory } from '@/lib/state'
+import { STORAGE_KEYS } from '@/lib/state/constants'
+
+const TEST_TOKEN = 'eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiJsb2NhbC10ZXN0LXVzZXIifQ.'
+
+function TokenHistoryHarness() {
+  const { tokenHistory, addToken } = useTokenHistory()
+  const { settings, updateSettings } = useSettings()
+
+  return (
+    <div>
+      <button type="button" onClick={() => addToken(TEST_TOKEN)}>
+        Add token
+      </button>
+      <button type="button" onClick={() => updateSettings({ persistTokenHistory: true })}>
+        Enable history
+      </button>
+      <output data-testid="history-enabled">
+        {settings.persistTokenHistory === true ? 'enabled' : 'disabled'}
+      </output>
+      <output data-testid="token-count">{tokenHistory.length}</output>
+    </div>
+  )
+}
+
+describe('token history privacy setting', () => {
+  beforeEach(() => {
+    cleanup()
+    window.localStorage.clear()
+  })
+
+  afterEach(() => {
+    cleanup()
+    window.localStorage.clear()
+  })
+
+  test('does not persist raw tokens until history is explicitly enabled', async () => {
+    const view = render(
+      <AppStateProvider>
+        <TokenHistoryHarness />
+      </AppStateProvider>
+    )
+
+    const buttons = view.container.getElementsByTagName('button')
+    fireEvent.click(buttons[0])
+
+    await waitFor(() => {
+      expect(view.getByTestId('token-count').textContent).toBe('0')
+      expect(window.localStorage.getItem(STORAGE_KEYS.TOKEN_HISTORY)).toBeNull()
+    })
+
+    fireEvent.click(buttons[1])
+    await waitFor(() => {
+      expect(view.getByTestId('history-enabled').textContent).toBe('enabled')
+    })
+
+    fireEvent.click(buttons[0])
+    await waitFor(() => {
+      expect(view.getByTestId('token-count').textContent).toBe('1')
+      const stored = JSON.parse(window.localStorage.getItem(STORAGE_KEYS.TOKEN_HISTORY) || '[]')
+      expect(stored[0].token).toBe(TEST_TOKEN)
+    })
+  })
+
+  test('treats legacy settings without the privacy flag as disabled', async () => {
+    window.localStorage.setItem(
+      STORAGE_KEYS.USER_SETTINGS,
+      JSON.stringify({
+        maxHistoryItems: 10,
+        tokenDisplayFormat: 'decoded',
+        enableDetailedValidation: true,
+        defaultTab: 'payload',
+      })
+    )
+
+    const view = render(
+      <AppStateProvider>
+        <TokenHistoryHarness />
+      </AppStateProvider>
+    )
+
+    fireEvent.click(view.container.getElementsByTagName('button')[0])
+
+    await waitFor(() => {
+      expect(view.getByTestId('history-enabled').textContent).toBe('disabled')
+      expect(view.getByTestId('token-count').textContent).toBe('0')
+    })
+  })
+})

--- a/src/tests/lib/worker.test.ts
+++ b/src/tests/lib/worker.test.ts
@@ -14,7 +14,11 @@ const fetchSpy = async (request: Request | string) => {
 }
 
 const createEnv = (
-  overrides: { CORS_ALLOWED_ORIGINS?: string; DEMO_TOKEN_SIGNING_SECRET?: string } = {}
+  overrides: {
+    CORS_ALLOWED_ORIGINS?: string
+    DEMO_REDIRECT_URIS?: string
+    DEMO_TOKEN_SIGNING_SECRET?: string
+  } = {}
 ) => ({
   ASSETS: {
     fetch: async () =>
@@ -93,6 +97,45 @@ describe('worker api', () => {
     expect(Array.isArray(data.keys)).toBe(true)
   })
 
+  test('rejects unregistered external demo authorization redirects', async () => {
+    const redirectUri = 'https://evil.example/callback'
+    const response = await worker.fetch(
+      buildRequest(
+        `/api/auth?response_type=code&client_id=demo-client&redirect_uri=${encodeURIComponent(redirectUri)}`
+      ),
+      createEnv()
+    )
+
+    expect(response.status).toBe(400)
+    expect(response.headers.get('Location')).toBeNull()
+    const data = await response.json()
+    expect(data.error).toBe('invalid_request')
+  })
+
+  test('allows exact configured demo authorization redirects', async () => {
+    const redirectUri = 'https://client.example.com/oauth/callback'
+    const response = await worker.fetch(
+      buildRequest(
+        `/api/auth?response_type=code&client_id=demo-client&redirect_uri=${encodeURIComponent(redirectUri)}`
+      ),
+      createEnv({ DEMO_REDIRECT_URIS: redirectUri })
+    )
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get('Location')?.startsWith(redirectUri)).toBe(true)
+  })
+
+  test('allows the local app callback across development ports', async () => {
+    const redirectUri = 'http://127.0.0.1:5173/oauth-playground/callback'
+    const request = new Request(
+      `http://localhost:8788/api/auth?response_type=code&client_id=demo-client&redirect_uri=${encodeURIComponent(redirectUri)}`
+    )
+    const response = await worker.fetch(request, createEnv())
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get('Location')?.startsWith(redirectUri)).toBe(true)
+  })
+
   test('echoes allowed origin when allowlist is set', async () => {
     const allowedOrigin = 'https://allowed.example'
     const response = await worker.fetch(
@@ -127,6 +170,28 @@ describe('worker api', () => {
     expect(fetchCalls.length).toBe(0)
   })
 
+  test('rejects insecure, local, private, and IP-literal cors proxy targets', async () => {
+    const blockedTargets = [
+      'http://issuer.example.com/.well-known/openid-configuration',
+      'https://localhost/.well-known/openid-configuration',
+      'https://127.0.0.1/.well-known/openid-configuration',
+      'https://10.0.0.8/.well-known/openid-configuration',
+      'https://169.254.169.254/.well-known/openid-configuration',
+      'https://203.0.113.10/.well-known/openid-configuration',
+      'https://issuer.example.com:8443/.well-known/openid-configuration',
+    ]
+
+    for (const targetUrl of blockedTargets) {
+      const response = await worker.fetch(
+        buildRequest(`/api/cors-proxy/${encodeURIComponent(targetUrl)}`),
+        createEnv()
+      )
+      expect(response.status).toBe(403)
+    }
+
+    expect(fetchCalls.length).toBe(0)
+  })
+
   test('proxies allowed target', async () => {
     const targetUrl = 'https://issuer.example.com/.well-known/openid-configuration'
     const response = await worker.fetch(
@@ -142,6 +207,82 @@ describe('worker api', () => {
 
     expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*')
     expect(response.headers.get('Access-Control-Allow-Methods')).toContain('GET')
+  })
+
+  test('strips credentials and arbitrary headers from cors proxy requests', async () => {
+    const targetUrl = 'https://issuer.example.com/.well-known/openid-configuration'
+    const response = await worker.fetch(
+      buildRequest(`/api/cors-proxy/${encodeURIComponent(targetUrl)}`, {
+        headers: {
+          Accept: 'application/json',
+          Authorization: 'Bearer browser-secret',
+          Cookie: 'session=browser-secret',
+          'X-Forwarded-For': '127.0.0.1',
+        },
+      }),
+      createEnv()
+    )
+
+    expect(response.status).toBe(200)
+    const forwardedRequest = fetchCalls[0] as Request
+    expect(forwardedRequest.headers.get('Accept')).toBe('application/json')
+    expect(forwardedRequest.headers.get('Authorization')).toBeNull()
+    expect(forwardedRequest.headers.get('Cookie')).toBeNull()
+    expect(forwardedRequest.headers.get('X-Forwarded-For')).toBeNull()
+    expect(forwardedRequest.redirect).toBe('manual')
+  })
+
+  test('blocks cors proxy redirects to unsafe targets', async () => {
+    const targetUrl = 'https://issuer.example.com/.well-known/openid-configuration'
+    globalThis.fetch = (async (request: Request | string) => {
+      fetchCalls.push(request)
+      return new Response(null, {
+        status: 302,
+        headers: { Location: 'http://127.0.0.1/.well-known/openid-configuration' },
+      })
+    }) as typeof fetch
+
+    const response = await worker.fetch(
+      buildRequest(`/api/cors-proxy/${encodeURIComponent(targetUrl)}`),
+      createEnv()
+    )
+
+    expect(response.status).toBe(403)
+    expect(fetchCalls.length).toBe(1)
+  })
+
+  test('revalidates safe cors proxy redirects and strips unsafe response headers', async () => {
+    const targetUrl = 'https://issuer.example.com/.well-known/openid-configuration'
+    globalThis.fetch = (async (request: Request | string) => {
+      fetchCalls.push(request)
+      if (fetchCalls.length === 1) {
+        return new Response(null, {
+          status: 302,
+          headers: { Location: '/tenant/discovery.json' },
+        })
+      }
+
+      return new Response('{"issuer":"https://issuer.example.com"}', {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'Set-Cookie': 'upstream=secret',
+          'X-Upstream-Internal': 'hidden',
+        },
+      })
+    }) as typeof fetch
+
+    const response = await worker.fetch(
+      buildRequest(`/api/cors-proxy/${encodeURIComponent(targetUrl)}`),
+      createEnv()
+    )
+
+    expect(response.status).toBe(200)
+    expect(fetchCalls.length).toBe(2)
+    expect((fetchCalls[1] as Request).url).toBe('https://issuer.example.com/tenant/discovery.json')
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+    expect(response.headers.get('Set-Cookie')).toBeNull()
+    expect(response.headers.get('X-Upstream-Internal')).toBeNull()
   })
 
   test('rate limits cors proxy requests', async () => {
@@ -233,7 +374,7 @@ describe('worker api', () => {
 
   test('accepts signed auth code and rejects tampered auth code in strict mode', async () => {
     const env = createEnv({ DEMO_TOKEN_SIGNING_SECRET: 'strict-signing-secret' })
-    const redirectUri = 'https://client.example.com/callback'
+    const redirectUri = 'https://app.test/oauth-playground/callback'
 
     const authResponse = await worker.fetch(
       buildRequest(
@@ -289,7 +430,7 @@ describe('worker api', () => {
 
   test('accepts signed refresh token and rejects tampered refresh token in strict mode', async () => {
     const env = createEnv({ DEMO_TOKEN_SIGNING_SECRET: 'strict-signing-secret' })
-    const redirectUri = 'https://client.example.com/callback'
+    const redirectUri = 'https://app.test/oauth-playground/callback'
 
     const authResponse = await worker.fetch(
       buildRequest(
@@ -397,7 +538,7 @@ describe('worker api', () => {
 
   test('keeps legacy auth-code and refresh-token behavior when strict secret is unset', async () => {
     const env = createEnv()
-    const redirectUri = 'https://client.example.com/callback'
+    const redirectUri = 'https://app.test/oauth-playground/callback'
 
     const authResponse = await worker.fetch(
       buildRequest(

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4,11 +4,13 @@
 import { DEMO_JWKS } from './lib/jwt/demo-key'
 import { signToken } from './lib/jwt/sign-token'
 import { CSP_INLINE_SCRIPT_SHA256 } from './csp-hashes'
+import { isAllowedDemoRedirectUri } from './features/oauthPlayground/utils/demo-redirect'
 
 type AssetsBinding = { fetch: (request: Request) => Promise<Response> }
 interface Env {
   ASSETS: AssetsBinding
   CORS_ALLOWED_ORIGINS?: string
+  DEMO_REDIRECT_URIS?: string
   DEMO_TOKEN_SIGNING_SECRET?: string
 }
 
@@ -17,6 +19,25 @@ type RateLimitConfig = { max: number; windowMs: number }
 
 const rateLimitBuckets = new Map<string, RateLimitBucket>()
 const CORS_PROXY_RATE_LIMIT: RateLimitConfig = { max: 60, windowMs: 60_000 }
+const CORS_PROXY_MAX_REDIRECTS = 3
+const CORS_PROXY_REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308])
+const CORS_PROXY_ALLOWED_REQUEST_HEADERS = new Set([
+  'accept',
+  'accept-language',
+  'cache-control',
+  'if-modified-since',
+  'if-none-match',
+])
+const CORS_PROXY_ALLOWED_RESPONSE_HEADERS = new Set([
+  'cache-control',
+  'content-language',
+  'content-length',
+  'content-type',
+  'date',
+  'etag',
+  'expires',
+  'last-modified',
+])
 const DEMO_RATE_LIMIT: RateLimitConfig = { max: 120, windowMs: 60_000 }
 const OIDC_PREFLIGHT_PROBE_RATE_LIMIT: RateLimitConfig = { max: 90, windowMs: 60_000 }
 const SIGNED_ENVELOPE_VERSION = 'v1'
@@ -105,6 +126,13 @@ function parseAllowedOrigins(env?: Env): string[] {
   return raw
     .split(',')
     .map((origin) => origin.trim())
+    .filter(Boolean)
+}
+
+function parseDemoRedirectUris(env?: Env): string[] {
+  return (env?.DEMO_REDIRECT_URIS ?? '')
+    .split(',')
+    .map((redirectUri) => redirectUri.trim())
     .filter(Boolean)
 }
 
@@ -341,11 +369,14 @@ async function handleAuthorization(request: Request, env: Env): Promise<Response
   const codeChallengeMethod = params.get('code_challenge_method') || undefined
   const nonce = params.get('nonce') || undefined
   const subject = normalizeDemoSubject(params.get('login_hint'))
+  const redirectAllowed = redirectUri
+    ? isAllowedDemoRedirectUri(redirectUri, request.url, parseDemoRedirectUris(env))
+    : false
 
   if (!clientId || !redirectUri) {
     return buildAuthorizationError(
       {
-        redirectUri,
+        redirectUri: redirectAllowed ? redirectUri : null,
         state,
         error: 'invalid_request',
         description: 'client_id and redirect_uri are required',
@@ -355,15 +386,13 @@ async function handleAuthorization(request: Request, env: Env): Promise<Response
     )
   }
 
-  try {
-    new URL(redirectUri)
-  } catch {
+  if (!redirectAllowed) {
     return buildAuthorizationError(
       {
         redirectUri: null,
         state,
         error: 'invalid_request',
-        description: 'redirect_uri is invalid',
+        description: 'redirect_uri is not registered for this demo provider',
       },
       request,
       env
@@ -719,7 +748,10 @@ function buildAuthorizationError(
   request: Request,
   env: Env
 ): Response {
-  if (opts.redirectUri) {
+  if (
+    opts.redirectUri &&
+    isAllowedDemoRedirectUri(opts.redirectUri, request.url, parseDemoRedirectUris(env))
+  ) {
     try {
       const redirect = new URL(opts.redirectUri)
       redirect.searchParams.set('error', opts.error)
@@ -1377,11 +1409,11 @@ async function handleCorsProxy(request: Request, env: Env): Promise<Response> {
 
   try {
     const targetUrl = decodeURIComponent(rest)
-    // Validate URL
-    new URL(targetUrl)
+    const initialTarget = new URL(targetUrl)
 
-    // Only allow well-known/JWKS-like endpoints; restrict to safe methods
-    if (!isAllowedEndpoint(targetUrl)) {
+    // Only proxy public HTTPS metadata endpoints. Local development targets are
+    // fetched directly by the browser and never need this server-side escape hatch.
+    if (!isSafeCorsProxyTarget(initialTarget, true)) {
       return new Response('This endpoint is not allowed', {
         status: 403,
         headers: corsHeaders(request, env),
@@ -1391,13 +1423,56 @@ async function handleCorsProxy(request: Request, env: Env): Promise<Response> {
       return new Response('Method not allowed', { status: 405, headers: corsHeaders(request, env) })
     }
 
-    const forward = new Request(targetUrl, {
-      method: request.method,
-      headers: filterHeaders(request.headers),
-    })
+    let currentTarget = initialTarget
+    let resp: Response | null = null
 
-    const resp = await fetch(forward)
-    const headers = new Headers(resp.headers)
+    for (let redirectCount = 0; redirectCount <= CORS_PROXY_MAX_REDIRECTS; redirectCount += 1) {
+      const forward = new Request(currentTarget.toString(), {
+        method: request.method,
+        headers: filterProxyRequestHeaders(request.headers),
+        redirect: 'manual',
+      })
+
+      resp = await fetch(forward)
+      if (!CORS_PROXY_REDIRECT_STATUSES.has(resp.status)) {
+        break
+      }
+
+      const location = resp.headers.get('Location')
+      if (!location) {
+        return new Response('Upstream redirect is missing a Location header', {
+          status: 502,
+          headers: corsHeaders(request, env),
+        })
+      }
+
+      if (redirectCount === CORS_PROXY_MAX_REDIRECTS) {
+        return new Response('Too many upstream redirects', {
+          status: 508,
+          headers: corsHeaders(request, env),
+        })
+      }
+
+      const nextTarget = new URL(location, currentTarget)
+      const crossedOrigin = nextTarget.origin !== currentTarget.origin
+      if (!isSafeCorsProxyTarget(nextTarget, crossedOrigin)) {
+        return new Response('Upstream redirect target is not allowed', {
+          status: 403,
+          headers: corsHeaders(request, env),
+        })
+      }
+
+      currentTarget = nextTarget
+    }
+
+    if (!resp) {
+      return new Response('Unable to fetch upstream endpoint', {
+        status: 502,
+        headers: corsHeaders(request, env),
+      })
+    }
+
+    const headers = filterProxyResponseHeaders(resp.headers)
     const proxyCorsHeaders = corsHeaders(request, env)
     for (const [key, value] of Object.entries(proxyCorsHeaders)) {
       headers.set(key, value)
@@ -1439,14 +1514,43 @@ function isAllowedEndpoint(urlStr: string): boolean {
   return isWellKnown || isJwks || isSamlMeta
 }
 
-function filterHeaders(headers: Headers): Headers {
+function isSafeCorsProxyTarget(url: URL, requireAllowedPath: boolean): boolean {
+  if (url.protocol !== 'https:' || url.username || url.password) {
+    return false
+  }
+
+  if (url.port && url.port !== '443') {
+    return false
+  }
+
+  if (isPrivateOrLocalHostname(url.hostname)) {
+    return false
+  }
+
+  // Identity metadata should be hosted by a DNS name. Rejecting every IP
+  // literal also closes alternate numeric forms of loopback/private targets.
+  if (parseIpv4Address(url.hostname) || url.hostname.includes(':')) {
+    return false
+  }
+
+  return !requireAllowedPath || isAllowedEndpoint(url.toString())
+}
+
+function filterProxyRequestHeaders(headers: Headers): Headers {
   const filtered = new Headers()
   for (const [k, v] of headers.entries()) {
     const key = k.toLowerCase()
-    if (key.startsWith('cf-')) continue
-    if (key.startsWith('cloudflare-')) continue
-    if (key === 'host' || key === 'origin' || key === 'referer') continue
+    if (!CORS_PROXY_ALLOWED_REQUEST_HEADERS.has(key)) continue
     filtered.set(k, v)
+  }
+  return filtered
+}
+
+function filterProxyResponseHeaders(headers: Headers): Headers {
+  const filtered = new Headers()
+  for (const [key, value] of headers.entries()) {
+    if (!CORS_PROXY_ALLOWED_RESPONSE_HEADERS.has(key.toLowerCase())) continue
+    filtered.set(key, value)
   }
   return filtered
 }


### PR DESCRIPTION
## Summary
- Centralize tool metadata so home cards, sidebar navigation, and breadcrumbs stay aligned
- Add local IAM utilities for token diffing, redirect URI debugging, SCIM validation, LDAP filter handling, and TOTP inspection
- Document the new tools and make token history opt-in by default
- Update sitemap and smoke tests for the new routes and headings

## Testing
- Not run (not requested)