### PR TITLE
fix: prevent infinite OIDC discovery retries

### DIFF
--- a/src/features/tokenInspector/components/TokenJwksResolver.tsx
+++ b/src/features/tokenInspector/components/TokenJwksResolver.tsx
@@ -19,8 +19,14 @@ interface TokenJwksResolverProps {
   isCurrentTokenDemo?: boolean // Flag from parent indicating if the current token is a demo one
   oidcConfig?: any // OIDC configuration from parent
   isLoadingOidcConfig?: boolean // OIDC config loading state
+  oidcConfigError?: Error | null
+  onFetchOidcConfig?: (issuerUrl: string) => Promise<void>
   preferredJwksUri?: string | null
   jwksFetcher?: OidcFetchFunction
+}
+
+function getDiscoveryErrorSummary(error: Error): string {
+  return error.message.split(/\s+-\s+/, 1)[0] || 'OIDC discovery failed'
 }
 
 export function TokenJwksResolver({
@@ -30,6 +36,8 @@ export function TokenJwksResolver({
   isCurrentTokenDemo = false, // Default to false if not provided
   oidcConfig,
   isLoadingOidcConfig,
+  oidcConfigError,
+  onFetchOidcConfig,
   preferredJwksUri,
   jwksFetcher,
 }: TokenJwksResolverProps) {
@@ -114,6 +122,8 @@ export function TokenJwksResolver({
         console.log(`Fetching JWKS directly from: ${oidcConfig.jwks_uri}`)
       }
       void fetchAndApplyJwks(oidcConfig.jwks_uri, true)
+    } else if (onFetchOidcConfig) {
+      void onFetchOidcConfig(issuerUrl)
     } else {
       toast.info('OIDC configuration not yet loaded. Please wait...')
     }
@@ -284,6 +294,11 @@ export function TokenJwksResolver({
             >
               {isLoadingOidcConfig || isJwksLoading ? 'Fetching...' : 'Fetch JWKS'}
             </Button>
+            {oidcConfigError && !isLoadingOidcConfig && (
+              <p className="text-xs text-destructive" role="alert">
+                Automatic discovery failed: {getDiscoveryErrorSummary(oidcConfigError)}
+              </p>
+            )}
           </div>
           <p className="text-xs text-muted-foreground">
             Fetches JWKS based on the token's 'iss' claim. Use this for real external tokens.

--- a/src/features/tokenInspector/components/TokenSignature.tsx
+++ b/src/features/tokenInspector/components/TokenSignature.tsx
@@ -17,6 +17,8 @@ interface TokenSignatureProps {
   isCurrentTokenDemo?: boolean // Flag indicating if the token being inspected is a demo one
   oidcConfig?: any // OIDC configuration from parent
   isLoadingOidcConfig?: boolean // OIDC config loading state
+  oidcConfigError?: Error | null
+  onFetchOidcConfig?: (issuerUrl: string) => Promise<void>
   preferredJwksUri?: string | null
   jwksFetcher?: OidcFetchFunction
 }
@@ -33,6 +35,8 @@ export function TokenSignature({
   isCurrentTokenDemo, // Use the flag passed from the parent
   oidcConfig,
   isLoadingOidcConfig,
+  oidcConfigError,
+  onFetchOidcConfig,
   preferredJwksUri,
   jwksFetcher,
 }: TokenSignatureProps) {
@@ -100,6 +104,8 @@ export function TokenSignature({
             isCurrentTokenDemo={isCurrentTokenDemo}
             oidcConfig={oidcConfig}
             isLoadingOidcConfig={isLoadingOidcConfig}
+            oidcConfigError={oidcConfigError}
+            onFetchOidcConfig={onFetchOidcConfig}
             preferredJwksUri={preferredJwksUri}
             jwksFetcher={jwksFetcher}
           />

--- a/src/features/tokenInspector/index.tsx
+++ b/src/features/tokenInspector/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import * as jose from 'jose'
 import { Card, CardContent } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -33,6 +33,7 @@ export function TokenInspector({ initialToken = null }: TokenInspectorProps) {
   const [activeTab, setActiveTab] = useState('payload')
   const [manualIssuerUrl, setManualIssuerUrl] = useState('') // Manual issuer URL override
   const [selectedEnvironment, setSelectedEnvironment] = useState<EnvironmentProfile | null>(null)
+  const lastOidcDiscoveryAttemptRef = useRef<string | null>(null)
 
   // Token decoder hook for decoding and validation logic
   const {
@@ -53,6 +54,7 @@ export function TokenInspector({ initialToken = null }: TokenInspectorProps) {
     data: oidcConfig,
     currentIssuer: oidcConfigIssuer,
     isLoading: isOidcConfigLoading,
+    error: oidcConfigError,
     fetchConfig: fetchOidcConfig,
   } = useOidcConfig()
 
@@ -88,16 +90,26 @@ export function TokenInspector({ initialToken = null }: TokenInspectorProps) {
   // Effect to fetch OIDC config when issuer changes
   useEffect(() => {
     if (!issuerUrl || isDemoToken || selectedEnvironment?.jwksEndpoint) {
+      if (!issuerUrl) {
+        lastOidcDiscoveryAttemptRef.current = null
+      }
       return
     }
 
     const hasConfigForIssuer = oidcConfig?.issuer === issuerUrl && oidcConfigIssuer === issuerUrl
 
-    if (!hasConfigForIssuer && !isOidcConfigLoading) {
+    if (
+      !hasConfigForIssuer &&
+      !isOidcConfigLoading &&
+      lastOidcDiscoveryAttemptRef.current !== issuerUrl
+    ) {
       if (import.meta?.env?.DEV) {
         console.log('Fetching OIDC config for issuer:', issuerUrl)
       }
-      fetchOidcConfig(issuerUrl)
+      // Mark the issuer before starting the request. A failed request toggles the loading
+      // state, which must not be interpreted as a reason to immediately retry forever.
+      lastOidcDiscoveryAttemptRef.current = issuerUrl
+      void fetchOidcConfig(issuerUrl)
     }
   }, [
     fetchOidcConfig,
@@ -118,6 +130,7 @@ export function TokenInspector({ initialToken = null }: TokenInspectorProps) {
     setJwks(null) // Reset loaded JWKS
     setManualIssuerUrl('') // Clear manual issuer override
     setSelectedEnvironment(null)
+    lastOidcDiscoveryAttemptRef.current = null
     resetState() // Call hook's reset function
     // Clear token from URL if it was present
     if (initialToken) {
@@ -327,6 +340,8 @@ export function TokenInspector({ initialToken = null }: TokenInspectorProps) {
                   isCurrentTokenDemo={isDemoToken} // Pass the flag indicating if CURRENT token is demo
                   oidcConfig={effectiveOidcConfig} // Pass OIDC config data
                   isLoadingOidcConfig={isOidcConfigLoading} // Pass loading state
+                  oidcConfigError={oidcConfigError}
+                  onFetchOidcConfig={(nextIssuerUrl) => fetchOidcConfig(nextIssuerUrl)}
                   preferredJwksUri={selectedEnvironment?.jwksEndpoint ?? null}
                 />
               </TabsContent>

--- a/src/tests/components/token-jwks-resolver.test.tsx
+++ b/src/tests/components/token-jwks-resolver.test.tsx
@@ -247,6 +247,21 @@ describe('JWKS Resolver Logic', () => {
 })
 
 describe('TokenJwksResolver component', () => {
+  test('shows a stable discovery error after automatic lookup fails', () => {
+    render(
+      <TokenJwksResolver
+        issuerUrl="https://issuer.example.com"
+        setIssuerUrl={() => {}}
+        onJwksResolved={() => {}}
+        oidcConfigError={new Error('OIDC discovery failed: 403 Forbidden - <html>blocked</html>')}
+      />
+    )
+
+    expect(document.body.textContent).toContain(
+      'Automatic discovery failed: OIDC discovery failed: 403 Forbidden'
+    )
+  })
+
   test('prefers a saved JWKS URI over the OIDC configuration JWKS URI', async () => {
     const preferredJwksUri = 'https://saved.example.com/.well-known/jwks.json'
     const discoveredJwksUri = 'https://issuer.example.com/.well-known/jwks.json'

--- a/src/tests/features/token-inspector-integration.test.tsx
+++ b/src/tests/features/token-inspector-integration.test.tsx
@@ -1,6 +1,18 @@
-import { describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, test } from 'bun:test'
+import { cleanup, render } from '@testing-library/react'
+import React from 'react'
 import { TokenInspector } from '@/features/tokenInspector'
 import { sampleJwt } from '../utils/test-api-mocks'
+import { waitForCondition } from '../utils/test-utils'
+
+afterEach(() => {
+  cleanup()
+})
+
+function createTokenWithIssuer(issuer: string): string {
+  const encode = (value: object) => Buffer.from(JSON.stringify(value)).toString('base64url')
+  return `${encode({ alg: 'RS256', kid: 'test-key' })}.${encode({ iss: issuer, sub: 'test-user' })}.signature`
+}
 
 /**
  * Basic tests for the token inspector functionality.
@@ -44,5 +56,29 @@ describe('Token Inspector Core Functionality', () => {
     // Invalid token format
     const invalidFormat = 'invalid-token'
     expect(invalidFormat.split('.').length).not.toBe(3)
+  })
+
+  test('attempts failed OIDC discovery only once until the user retries', async () => {
+    const originalFetch = globalThis.fetch
+    let discoveryRequests = 0
+    globalThis.fetch = (async () => {
+      discoveryRequests += 1
+      return new Response(JSON.stringify({ error: 'Forbidden' }), {
+        status: 403,
+        statusText: 'Forbidden',
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }) as typeof fetch
+
+    try {
+      render(<TokenInspector initialToken={createTokenWithIssuer('https://issuer.example.com')} />)
+
+      expect(await waitForCondition(() => discoveryRequests === 1)).toBe(true)
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      expect(discoveryRequests).toBe(1)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
   })
 })


### PR DESCRIPTION
## Summary

- Prevent repeated OIDC discovery requests after a failed lookup.
- Allow users to manually retry discovery.
- Display a concise discovery error in the JWKS resolver.
- Add component and integration coverage for failed discovery behavior.

## Testing

- Added tests verifying stable error rendering and single-attempt discovery behavior.